### PR TITLE
Fixes some acceptance tests in Virtual Machine basic

### DIFF
--- a/internal/services/compute/virtual_machine_resource.go
+++ b/internal/services/compute/virtual_machine_resource.go
@@ -251,6 +251,7 @@ func virtualMachine() *pluginsdk.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								string(compute.PremiumLRS),
 								string(compute.StandardLRS),
+								string(compute.StandardSSDLRS),
 							}, true),
 						},
 

--- a/internal/services/compute/virtual_machine_resource_t_managed_disks_resource_test.go
+++ b/internal/services/compute/virtual_machine_resource_t_managed_disks_resource_test.go
@@ -448,7 +448,7 @@ resource "azurestack_virtual_machine" "test" {
   location              = azurestack_resource_group.test.location
   resource_group_name   = azurestack_resource_group.test.name
   network_interface_ids = [azurestack_network_interface.test.id]
-  vm_size               = "Standard_M64s"
+  vm_size               = "Standard_DS13"
 
   delete_os_disk_on_termination = true
 
@@ -536,7 +536,7 @@ resource "azurestack_virtual_machine" "test" {
   location              = azurestack_resource_group.test.location
   resource_group_name   = azurestack_resource_group.test.name
   network_interface_ids = [azurestack_network_interface.test.id]
-  vm_size               = "Standard_M64s"
+  vm_size               = "Standard_DS13"
 
   delete_os_disk_on_termination = true
 

--- a/internal/services/compute/virtual_machine_resource_t_unmanaged_disks_resource_test.go
+++ b/internal/services/compute/virtual_machine_resource_t_unmanaged_disks_resource_test.go
@@ -641,7 +641,7 @@ resource "azurestack_virtual_machine" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 


### PR DESCRIPTION
- Small edits in some configs, so it can pass acceptance tests because of image non-existant or similar
- Added a variable for validation of `vm_size`

Passed Acceptance tests in VM basic
- TestAccVirtualMachine_basicLinuxMachine_managedDisk_explicit
- TestAccVirtualMachine_basicLinuxMachine_managedDisk_implicit
- TestAccVirtualMachine_basicLinuxMachine_managedDisk_attach
- TestAccVirtualMachine_basicLinuxMachine_managedDisk_changeOsWriteAcceleratorEnabled
- TestAccVirtualMachine_basicLinuxMachine_managedDisk_withWriteAcceleratorEnabled
- TestAccVirtualMachine_basicLinuxMachine_managedDisk_changeWriteAcceleratorEnabled
- TestAccVirtualMachine_basicLinuxMachine
- TestAccVirtualMachine_basicLinuxMachine_storageBlob_attach
- TestAccVirtualMachine_basicLinuxMachineSSHOnly
- TestAccVirtualMachine_basicLinuxMachine_disappears
- TestAccVirtualMachine_winTimeZone
