### PR TITLE
Add virtual network peering

### DIFF
--- a/internal/services/network/client/client.go
+++ b/internal/services/network/client/client.go
@@ -18,6 +18,7 @@ type Client struct {
 	VnetGatewayConnectionsClient    *network.VirtualNetworkGatewayConnectionsClient
 	VnetGatewayClient               *network.VirtualNetworkGatewaysClient
 	VnetClient                      *network.VirtualNetworksClient
+	VnetPeeringsClient              *network.VirtualNetworkPeeringsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -97,5 +98,6 @@ func NewClient(o *common.ClientOptions) *Client {
 		VnetGatewayConnectionsClient:    &VnetGatewayConnectionsClient,
 		VnetGatewayClient:               &VnetGatewayClient,
 		VnetClient:                      &VnetClient,
+		VnetPeeringsClient:              &VnetPeeringsClient,
 	}
 }

--- a/internal/services/network/parse/virtual_network_peering.go
+++ b/internal/services/network/parse/virtual_network_peering.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type VirtualNetworkPeeringId struct {
+	SubscriptionId     string
+	ResourceGroup      string
+	VirtualNetworkName string
+	Name               string
+}
+
+func NewVirtualNetworkPeeringID(subscriptionId, resourceGroup, virtualNetworkName, name string) VirtualNetworkPeeringId {
+	return VirtualNetworkPeeringId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroup:      resourceGroup,
+		VirtualNetworkName: virtualNetworkName,
+		Name:               name,
+	}
+}
+
+func (id VirtualNetworkPeeringId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Virtual Network Name %q", id.VirtualNetworkName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Network Peering", segmentsStr)
+}
+
+func (id VirtualNetworkPeeringId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/virtualNetworkPeerings/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualNetworkName, id.Name)
+}
+
+// VirtualNetworkPeeringID parses a VirtualNetworkPeering ID into an VirtualNetworkPeeringId struct
+func VirtualNetworkPeeringID(input string) (*VirtualNetworkPeeringId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := VirtualNetworkPeeringId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.VirtualNetworkName, err = id.PopSegment("virtualNetworks"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("virtualNetworkPeerings"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/network/parse/virtual_network_peering_test.go
+++ b/internal/services/network/parse/virtual_network_peering_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = VirtualNetworkPeeringId{}
+
+func TestVirtualNetworkPeeringIDFormatter(t *testing.T) {
+	actual := NewVirtualNetworkPeeringID("12345678-1234-9876-4563-123456789012", "resGroup1", "vnet1", "vnetPeering1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/vnetPeering1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualNetworkPeeringID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *VirtualNetworkPeeringId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing VirtualNetworkName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for VirtualNetworkName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/vnet1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/vnetPeering1",
+			Expected: &VirtualNetworkPeeringId{
+				SubscriptionId:     "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:      "resGroup1",
+				VirtualNetworkName: "vnet1",
+				Name:               "vnetPeering1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/VIRTUALNETWORKS/VNET1/VIRTUALNETWORKPEERINGS/VNETPEERING1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := VirtualNetworkPeeringID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.VirtualNetworkName != v.Expected.VirtualNetworkName {
+			t.Fatalf("Expected %q but got %q for VirtualNetworkName", v.Expected.VirtualNetworkName, actual.VirtualNetworkName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -50,5 +50,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurestack_virtual_network_gateway_connection": virtualNetworkGatewayConnection(),
 		"azurestack_virtual_network_gateway":            virtualNetworkGateway(),
 		"azurestack_local_network_gateway":              localNetworkGateway(),
+		"azurestack_virtual_network_peering":            virtualNetworkPeering(),
 	}
 }

--- a/internal/services/network/resourceids.go
+++ b/internal/services/network/resourceids.go
@@ -12,6 +12,7 @@ package network
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NetworkGatewayConnection -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/connections/connection1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=LocalNetworkGateway -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/localNetworkGateways/localNetworkGateway1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=SecurityRule -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/networkSecurityGroups/acceptanceTestSecurityGroup1/securityRules/securityRules1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualNetworkPeering -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/vnetPeering1
 
 // Application Gateway
 

--- a/internal/services/network/validate/virtual_network_peering_id.go
+++ b/internal/services/network/validate/virtual_network_peering_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/network/parse"
+)
+
+func VirtualNetworkPeeringID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.VirtualNetworkPeeringID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/network/validate/virtual_network_peering_id_test.go
+++ b/internal/services/network/validate/virtual_network_peering_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestVirtualNetworkPeeringID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing VirtualNetworkName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VirtualNetworkName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/vnet1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/vnetPeering1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/VIRTUALNETWORKS/VNET1/VIRTUALNETWORKPEERINGS/VNETPEERING1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := VirtualNetworkPeeringID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -1,0 +1,234 @@
+package network
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/timeouts"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/utils"
+)
+
+// peerMutex is used to prevent multiple Peering resources being created, updated
+// or deleted at the same time
+var peerMutex = &sync.Mutex{}
+
+func virtualNetworkPeering() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: virtualNetworkPeeringCreateUpdate,
+		Read:   virtualNetworkPeeringRead,
+		Update: virtualNetworkPeeringCreateUpdate,
+		Delete: virtualNetworkPeeringDelete,
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.VirtualNetworkPeeringID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"virtual_network_name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"remote_virtual_network_id": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"allow_virtual_network_access": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"allow_forwarded_traffic": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"allow_gateway_transit": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"use_remote_gateways": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func virtualNetworkPeeringCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VnetPeeringsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[INFO] preparing arguments for Azure ARM virtual network peering creation.")
+
+	id := parse.NewVirtualNetworkPeeringID(subscriptionId, d.Get("resource_group_name").(string), d.Get("virtual_network_name").(string), d.Get("name").(string))
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurestack_virtual_network_peering", id.ID())
+		}
+	}
+
+	peer := network.VirtualNetworkPeering{
+		Name:                                  &id.Name,
+		VirtualNetworkPeeringPropertiesFormat: getVirtualNetworkPeeringProperties(d),
+	}
+
+	peerMutex.Lock()
+	defer peerMutex.Unlock()
+
+	if err := pluginsdk.Retry(300*time.Second, retryVnetPeeringsClientCreateUpdate(d, id.ResourceGroup, id.VirtualNetworkName, id.Name, peer, meta)); err != nil {
+		return err
+	}
+
+	d.SetId(id.ID())
+
+	return virtualNetworkPeeringRead(d, meta)
+}
+
+func virtualNetworkPeeringRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VnetPeeringsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualNetworkPeeringID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("making Read request on %s: %+v", *id, err)
+	}
+
+	// update appropriate values
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("name", id.Name)
+	d.Set("virtual_network_name", id.VirtualNetworkName)
+
+	if peer := resp.VirtualNetworkPeeringPropertiesFormat; peer != nil {
+		d.Set("allow_virtual_network_access", peer.AllowVirtualNetworkAccess)
+		d.Set("allow_forwarded_traffic", peer.AllowForwardedTraffic)
+		d.Set("allow_gateway_transit", peer.AllowGatewayTransit)
+		d.Set("use_remote_gateways", peer.UseRemoteGateways)
+		if network := peer.RemoteVirtualNetwork; network != nil {
+			d.Set("remote_virtual_network_id", network.ID)
+		}
+	}
+
+	return nil
+}
+
+func virtualNetworkPeeringDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.VnetPeeringsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualNetworkPeeringID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	peerMutex.Lock()
+	defer peerMutex.Unlock()
+
+	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name)
+	if err != nil {
+		return fmt.Errorf("deleting %s: %+v", *id, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
+	}
+
+	return err
+}
+
+func getVirtualNetworkPeeringProperties(d *pluginsdk.ResourceData) *network.VirtualNetworkPeeringPropertiesFormat {
+	allowVirtualNetworkAccess := d.Get("allow_virtual_network_access").(bool)
+	allowForwardedTraffic := d.Get("allow_forwarded_traffic").(bool)
+	allowGatewayTransit := d.Get("allow_gateway_transit").(bool)
+	useRemoteGateways := d.Get("use_remote_gateways").(bool)
+	remoteVirtualNetworkID := d.Get("remote_virtual_network_id").(string)
+
+	return &network.VirtualNetworkPeeringPropertiesFormat{
+		AllowVirtualNetworkAccess: &allowVirtualNetworkAccess,
+		AllowForwardedTraffic:     &allowForwardedTraffic,
+		AllowGatewayTransit:       &allowGatewayTransit,
+		UseRemoteGateways:         &useRemoteGateways,
+		RemoteVirtualNetwork: &network.SubResource{
+			ID: &remoteVirtualNetworkID,
+		},
+	}
+}
+
+func retryVnetPeeringsClientCreateUpdate(d *pluginsdk.ResourceData, resGroup string, vnetName string, name string, peer network.VirtualNetworkPeering, meta interface{}) func() *pluginsdk.RetryError {
+	return func() *pluginsdk.RetryError {
+		vnetPeeringsClient := meta.(*clients.Client).Network.VnetPeeringsClient
+		ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+		defer cancel()
+
+		future, err := vnetPeeringsClient.CreateOrUpdate(ctx, resGroup, vnetName, name, peer)
+		if err != nil {
+			if utils.ResponseErrorIsRetryable(err) {
+				return pluginsdk.RetryableError(err)
+			} else if future.Response().StatusCode == 400 && strings.Contains(err.Error(), "ReferencedResourceNotProvisioned") {
+				// Resource is not yet ready, this may be the case if the Vnet was just created or another peering was just initiated.
+				return pluginsdk.RetryableError(err)
+			}
+
+			return pluginsdk.NonRetryableError(err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, vnetPeeringsClient.Client); err != nil {
+			return pluginsdk.NonRetryableError(err)
+		}
+
+		return nil
+	}
+}

--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-provider-azurestack/internal/az/resourceid"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/tf"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/timeouts"
@@ -63,7 +63,7 @@ func virtualNetworkPeering() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: resourceid.ValidateResourceID,
+				ValidateFunc: validate.VirtualNetworkID,
 			},
 
 			"allow_virtual_network_access": {

--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -196,7 +196,6 @@ func virtualNetworkPeeringDelete(d *pluginsdk.ResourceData, meta interface{}) er
 }
 
 func getVirtualNetworkPeeringProperties(d *pluginsdk.ResourceData) *network.VirtualNetworkPeeringPropertiesFormat {
-
 	return &network.VirtualNetworkPeeringPropertiesFormat{
 		AllowVirtualNetworkAccess: pointer.FromBool(d.Get("allow_virtual_network_access").(bool)),
 		AllowForwardedTraffic:     pointer.FromBool(d.Get("allow_forwarded_traffic").(bool)),

--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -8,7 +8,10 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/az/resourceid"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/tf"
@@ -41,23 +44,26 @@ func virtualNetworkPeering() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"virtual_network_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"remote_virtual_network_id": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: resourceid.ValidateResourceID,
 			},
 
 			"allow_virtual_network_access": {
@@ -190,19 +196,14 @@ func virtualNetworkPeeringDelete(d *pluginsdk.ResourceData, meta interface{}) er
 }
 
 func getVirtualNetworkPeeringProperties(d *pluginsdk.ResourceData) *network.VirtualNetworkPeeringPropertiesFormat {
-	allowVirtualNetworkAccess := d.Get("allow_virtual_network_access").(bool)
-	allowForwardedTraffic := d.Get("allow_forwarded_traffic").(bool)
-	allowGatewayTransit := d.Get("allow_gateway_transit").(bool)
-	useRemoteGateways := d.Get("use_remote_gateways").(bool)
-	remoteVirtualNetworkID := d.Get("remote_virtual_network_id").(string)
 
 	return &network.VirtualNetworkPeeringPropertiesFormat{
-		AllowVirtualNetworkAccess: &allowVirtualNetworkAccess,
-		AllowForwardedTraffic:     &allowForwardedTraffic,
-		AllowGatewayTransit:       &allowGatewayTransit,
-		UseRemoteGateways:         &useRemoteGateways,
+		AllowVirtualNetworkAccess: pointer.FromBool(d.Get("allow_virtual_network_access").(bool)),
+		AllowForwardedTraffic:     pointer.FromBool(d.Get("allow_forwarded_traffic").(bool)),
+		AllowGatewayTransit:       pointer.FromBool(d.Get("allow_gateway_transit").(bool)),
+		UseRemoteGateways:         pointer.FromBool(d.Get("use_remote_gateways").(bool)),
 		RemoteVirtualNetwork: &network.SubResource{
-			ID: &remoteVirtualNetworkID,
+			ID: pointer.FromString(d.Get("remote_virtual_network_id").(string)),
 		},
 	}
 }

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -1,0 +1,218 @@
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/network/parse"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/utils"
+)
+
+type VirtualNetworkPeeringResource struct{}
+
+func TestAccVirtualNetworkPeering_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_virtual_network_peering", "test1")
+	r := VirtualNetworkPeeringResource{}
+	secondResourceName := "azurestack_virtual_network_peering.test2"
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(secondResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("allow_virtual_network_access").HasValue("true"),
+				acceptance.TestCheckResourceAttr(secondResourceName, "allow_virtual_network_access", "true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualNetworkPeering_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_virtual_network_peering", "test1")
+	r := VirtualNetworkPeeringResource{}
+	secondResourceName := "azurestack_virtual_network_peering.test2"
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(secondResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccVirtualNetworkPeering_disappears(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_virtual_network_peering", "test1")
+	r := VirtualNetworkPeeringResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basic,
+			TestResource: r,
+		}),
+	})
+}
+
+func TestAccVirtualNetworkPeering_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_virtual_network_peering", "test1")
+	r := VirtualNetworkPeeringResource{}
+	secondResourceName := "azurestack_virtual_network_peering.test2"
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(secondResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("allow_virtual_network_access").HasValue("true"),
+				acceptance.TestCheckResourceAttr(secondResourceName, "allow_virtual_network_access", "true"),
+				check.That(data.ResourceName).Key("allow_forwarded_traffic").HasValue("false"),
+				acceptance.TestCheckResourceAttr(secondResourceName, "allow_forwarded_traffic", "false"),
+			),
+		},
+
+		{
+			Config: r.basicUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(secondResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("allow_virtual_network_access").HasValue("true"),
+				acceptance.TestCheckResourceAttr(secondResourceName, "allow_virtual_network_access", "true"),
+				check.That(data.ResourceName).Key("allow_forwarded_traffic").HasValue("true"),
+				acceptance.TestCheckResourceAttr(secondResourceName, "allow_forwarded_traffic", "true"),
+			),
+		},
+	})
+}
+
+func (t VirtualNetworkPeeringResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.VirtualNetworkPeeringID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := clients.Network.VnetPeeringsClient.Get(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (r VirtualNetworkPeeringResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.VirtualNetworkPeeringID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	future, err := client.Network.VnetPeeringsClient.Delete(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("deleting on virtual network peering: %+v", err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Network.VnetPeeringsClient.Client); err != nil {
+		return nil, fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (VirtualNetworkPeeringResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurestack" {
+  features {}
+}
+resource "azurestack_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+resource "azurestack_virtual_network" "test1" {
+  name                = "acctestvirtnet-1-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  address_space       = ["10.0.1.0/24"]
+  location            = azurestack_resource_group.test.location
+}
+resource "azurestack_virtual_network" "test2" {
+  name                = "acctestvirtnet-2-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  address_space       = ["10.0.2.0/24"]
+  location            = azurestack_resource_group.test.location
+}
+resource "azurestack_virtual_network_peering" "test1" {
+  name                         = "acctestpeer-1-%d"
+  resource_group_name          = azurestack_resource_group.test.name
+  virtual_network_name         = azurestack_virtual_network.test1.name
+  remote_virtual_network_id    = azurestack_virtual_network.test2.id
+  allow_virtual_network_access = true
+}
+resource "azurestack_virtual_network_peering" "test2" {
+  name                         = "acctestpeer-2-%d"
+  resource_group_name          = azurestack_resource_group.test.name
+  virtual_network_name         = azurestack_virtual_network.test2.name
+  remote_virtual_network_id    = azurestack_virtual_network.test1.id
+  allow_virtual_network_access = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r VirtualNetworkPeeringResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurestack_virtual_network_peering" "import" {
+  name                         = azurestack_virtual_network_peering.test1.name
+  resource_group_name          = azurestack_virtual_network_peering.test1.resource_group_name
+  virtual_network_name         = azurestack_virtual_network_peering.test1.virtual_network_name
+  remote_virtual_network_id    = azurestack_virtual_network_peering.test1.remote_virtual_network_id
+  allow_virtual_network_access = azurestack_virtual_network_peering.test1.allow_virtual_network_access
+}
+`, r.basic(data))
+}
+
+func (VirtualNetworkPeeringResource) basicUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurestack" {
+  features {}
+}
+resource "azurestack_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+resource "azurestack_virtual_network" "test1" {
+  name                = "acctestvirtnet-1-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  address_space       = ["10.0.1.0/24"]
+  location            = azurestack_resource_group.test.location
+}
+resource "azurestack_virtual_network" "test2" {
+  name                = "acctestvirtnet-2-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  address_space       = ["10.0.2.0/24"]
+  location            = azurestack_resource_group.test.location
+}
+resource "azurestack_virtual_network_peering" "test1" {
+  name                         = "acctestpeer-1-%d"
+  resource_group_name          = azurestack_resource_group.test.name
+  virtual_network_name         = azurestack_virtual_network.test1.name
+  remote_virtual_network_id    = azurestack_virtual_network.test2.id
+  allow_forwarded_traffic      = true
+  allow_virtual_network_access = true
+}
+resource "azurestack_virtual_network_peering" "test2" {
+  name                         = "acctestpeer-2-%d"
+  resource_group_name          = azurestack_resource_group.test.name
+  virtual_network_name         = azurestack_virtual_network.test2.name
+  remote_virtual_network_id    = azurestack_virtual_network.test1.id
+  allow_forwarded_traffic      = true
+  allow_virtual_network_access = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -80,7 +80,7 @@ func TestAccVirtualNetworkPeering_update(t *testing.T) {
 				acceptance.TestCheckResourceAttr(secondResourceName, "allow_forwarded_traffic", "false"),
 			),
 		},
-
+		data.ImportStep(),
 		{
 			Config: r.basicUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -92,6 +92,7 @@ func TestAccVirtualNetworkPeering_update(t *testing.T) {
 				acceptance.TestCheckResourceAttr(secondResourceName, "allow_forwarded_traffic", "true"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -131,22 +132,26 @@ func (VirtualNetworkPeeringResource) basic(data acceptance.TestData) string {
 provider "azurestack" {
   features {}
 }
+
 resource "azurestack_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
 }
+
 resource "azurestack_virtual_network" "test1" {
   name                = "acctestvirtnet-1-%d"
   resource_group_name = azurestack_resource_group.test.name
   address_space       = ["10.0.1.0/24"]
   location            = azurestack_resource_group.test.location
 }
+
 resource "azurestack_virtual_network" "test2" {
   name                = "acctestvirtnet-2-%d"
   resource_group_name = azurestack_resource_group.test.name
   address_space       = ["10.0.2.0/24"]
   location            = azurestack_resource_group.test.location
 }
+
 resource "azurestack_virtual_network_peering" "test1" {
   name                         = "acctestpeer-1-%d"
   resource_group_name          = azurestack_resource_group.test.name
@@ -154,6 +159,7 @@ resource "azurestack_virtual_network_peering" "test1" {
   remote_virtual_network_id    = azurestack_virtual_network.test2.id
   allow_virtual_network_access = true
 }
+
 resource "azurestack_virtual_network_peering" "test2" {
   name                         = "acctestpeer-2-%d"
   resource_group_name          = azurestack_resource_group.test.name
@@ -182,22 +188,26 @@ func (VirtualNetworkPeeringResource) basicUpdate(data acceptance.TestData) strin
 provider "azurestack" {
   features {}
 }
+
 resource "azurestack_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
 }
+
 resource "azurestack_virtual_network" "test1" {
   name                = "acctestvirtnet-1-%d"
   resource_group_name = azurestack_resource_group.test.name
   address_space       = ["10.0.1.0/24"]
   location            = azurestack_resource_group.test.location
 }
+
 resource "azurestack_virtual_network" "test2" {
   name                = "acctestvirtnet-2-%d"
   resource_group_name = azurestack_resource_group.test.name
   address_space       = ["10.0.2.0/24"]
   location            = azurestack_resource_group.test.location
 }
+
 resource "azurestack_virtual_network_peering" "test1" {
   name                         = "acctestpeer-1-%d"
   resource_group_name          = azurestack_resource_group.test.name
@@ -206,6 +216,7 @@ resource "azurestack_virtual_network_peering" "test1" {
   allow_forwarded_traffic      = true
   allow_virtual_network_access = true
 }
+
 resource "azurestack_virtual_network_peering" "test2" {
   name                         = "acctestpeer-2-%d"
   resource_group_name          = azurestack_resource_group.test.name

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -55,35 +55,14 @@ resource "azurestack_virtual_network_peering" "example-2" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the virtual network peering. Changing this
-    forces a new resource to be created.
-
-* `virtual_network_name` - (Required) The name of the virtual network. Changing
-    this forces a new resource to be created.
-
-* `remote_virtual_network_id` - (Required) The full Azure resource ID of the
-    remote virtual network.  Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the virtual network peering. Changing this forces a new resource to be
-    created.
-
-* `allow_virtual_network_access` - (Optional) Controls if the VMs in the remote
-    virtual network can access VMs in the local virtual network. Defaults to
-    true.
-
-* `allow_forwarded_traffic` - (Optional) Controls if forwarded traffic from  VMs
-    in the remote virtual network is allowed. Defaults to false.
-
-* `allow_gateway_transit` - (Optional) Controls gatewayLinks can be used in the
-    remote virtual network’s link to the local virtual network.
-
-* `use_remote_gateways` - (Optional) Controls if remote gateways can be used on
-    the local virtual network. If the flag is set to `true`, and
-    `allow_gateway_transit` on the remote peering is also `true`, virtual network will
-    use gateways of remote virtual network for transit. Only one peering can
-    have this flag set to `true`. This flag cannot be set if virtual network
-    already has a gateway. Defaults to `false`.
+* `name` - (Required) The name of the virtual network peering. Changing this forces a new resource to be created.
+* `virtual_network_name` - (Required) The name of the virtual network. Changing this forces a new resource to be created.
+* `remote_virtual_network_id` - (Required) The full Azure resource ID of the remote virtual network.  Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the virtual network peering. Changing this forces a new resource to be created.
+* `allow_virtual_network_access` - (Optional) Controls if the VMs in the remote virtual network can access VMs in the local virtual network. Defaults to true.
+* `allow_forwarded_traffic` - (Optional) Controls if forwarded traffic from VMs in the remote virtual network is allowed. Defaults to false.
+* `allow_gateway_transit` - (Optional) Controls gatewayLinks can be used in the remote virtual network’s link to the local virtual network.
+* `use_remote_gateways` - (Optional) Controls if remote gateways can be used on the local virtual network. If the flag is set to `true`, and `allow_gateway_transit` on the remote peering is also `true`, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to `true`. This flag cannot be set if virtual network already has a gateway. Defaults to `false`.
 
 
 ## Attributes Reference

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -1,0 +1,114 @@
+---
+subcategory: "Network"
+layout: "azurestack"
+page_title: "Azure Resource Manager: azurestack_virtual_network_peering"
+description: |-
+  Manages a virtual network peering which allows resources to access other
+  resources in the linked virtual network.
+---
+
+# azurestack_virtual_network_peering
+
+Manages a virtual network peering which allows resources to access other
+resources in the linked virtual network.
+
+## Example Usage
+
+```hcl
+resource "azurestack_resource_group" "example" {
+  name     = "peeredvnets-rg"
+  location = "ashregion"
+}
+
+resource "azurestack_virtual_network" "example-1" {
+  name                = "peternetwork1"
+  resource_group_name = azurestack_resource_group.example.name
+  address_space       = ["10.0.1.0/24"]
+  location            = "ashregion"
+}
+
+resource "azurestack_virtual_network" "example-2" {
+  name                = "peternetwork2"
+  resource_group_name = azurestack_resource_group.example.name
+  address_space       = ["10.0.2.0/24"]
+  location            = "ashregion"
+}
+
+resource "azurestack_virtual_network_peering" "example-1" {
+  name                      = "peer1to2"
+  resource_group_name       = azurestack_resource_group.example.name
+  virtual_network_name      = azurestack_virtual_network.example-1.name
+  remote_virtual_network_id = azurestack_virtual_network.example-2.id
+}
+
+resource "azurestack_virtual_network_peering" "example-2" {
+  name                      = "peer2to1"
+  resource_group_name       = azurestack_resource_group.example.name
+  virtual_network_name      = azurestack_virtual_network.example-2.name
+  remote_virtual_network_id = azurestack_virtual_network.example-1.id
+}
+```
+
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the virtual network peering. Changing this
+    forces a new resource to be created.
+
+* `virtual_network_name` - (Required) The name of the virtual network. Changing
+    this forces a new resource to be created.
+
+* `remote_virtual_network_id` - (Required) The full Azure resource ID of the
+    remote virtual network.  Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the virtual network peering. Changing this forces a new resource to be
+    created.
+
+* `allow_virtual_network_access` - (Optional) Controls if the VMs in the remote
+    virtual network can access VMs in the local virtual network. Defaults to
+    true.
+
+* `allow_forwarded_traffic` - (Optional) Controls if forwarded traffic from  VMs
+    in the remote virtual network is allowed. Defaults to false.
+
+* `allow_gateway_transit` - (Optional) Controls gatewayLinks can be used in the
+    remote virtual network’s link to the local virtual network.
+
+* `use_remote_gateways` - (Optional) Controls if remote gateways can be used on
+    the local virtual network. If the flag is set to `true`, and
+    `allow_gateway_transit` on the remote peering is also `true`, virtual network will
+    use gateways of remote virtual network for transit. Only one peering can
+    have this flag set to `true`. This flag cannot be set if virtual network
+    already has a gateway. Defaults to `false`.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Virtual Network Peering.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Virtual Network Peering.
+* `update` - (Defaults to 30 minutes) Used when updating the Virtual Network Peering.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Network Peering.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Virtual Network Peering.
+
+## Note
+
+Virtual Network peerings cannot be created, updated or deleted concurrently.
+
+## Import
+
+Virtual Network Peerings can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurestack_virtual_network_peering.examplePeering /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/virtualNetworkPeerings/myvnet1peering
+```


### PR DESCRIPTION
This pull requests adds possibility to create virtual network peering on Azure Stack Hub.

The code is mostly same as in azurerm, with the only difference that there is no global peering on ASH.
