### PR TITLE
Refactor in public ip resource and datasource

### DIFF
--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/az/tags"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
@@ -53,9 +54,24 @@ func publicIp() *pluginsdk.Resource {
 
 			"resource_group_name": commonschema.ResourceGroupName(),
 
+			"public_ip_address_allocation": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: suppress.CaseDifference,
+				ExactlyOneOf:     []string{"public_ip_address_allocation", "allocation_method"},
+				Deprecated:       "the `public_ip_address_allocation` property has been renamed to `allocation_method`",
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.Dynamic),
+					string(network.Static),
+				}, true),
+			},
+
 			"allocation_method": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
+				Type:         pluginsdk.TypeString,
+				Optional:     true, // TODO required when deprecation completed
+				Computed:     true,
+				ExactlyOneOf: []string{"public_ip_address_allocation", "allocation_method"},
 				ValidateFunc: validation.StringInSlice([]string{
 					string(network.Static),
 					string(network.Dynamic),
@@ -146,6 +162,9 @@ func publicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	idleTimeout := d.Get("idle_timeout_in_minutes").(int)
 	ipVersion := network.IPVersion(d.Get("ip_version").(string))
 	ipAllocationMethod := d.Get("allocation_method").(string)
+	if ipAllocationMethod == "" {
+		ipAllocationMethod = d.Get("public_ip_address_allocation").(string)
+	}
 
 	if strings.EqualFold(sku, "standard") {
 		if !strings.EqualFold(ipAllocationMethod, "static") {
@@ -228,6 +247,7 @@ func publicIpRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	if props := resp.PublicIPAddressPropertiesFormat; props != nil {
 		d.Set("allocation_method", string(props.PublicIPAllocationMethod))
+		d.Set("public_ip_address_allocation", string(props.PublicIPAllocationMethod))
 		d.Set("ip_version", string(props.PublicIPAddressVersion))
 
 		if settings := props.DNSSettings; settings != nil {

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -340,28 +340,6 @@ resource "azurestack_public_ip" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, ipVersion)
 }
 
-func (PublicIPResource) standard_withIPVersion(data acceptance.TestData, ipVersion string) string {
-	return fmt.Sprintf(`
-provider "azurestack" {
-  features {}
-}
-
-resource "azurestack_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurestack_public_ip" "test" {
-  name                = "acctestpublicip-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  allocation_method   = "Static"
-  ip_version          = "%s"
-  sku                 = "Standard"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, ipVersion)
-}
-
 func (PublicIPResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurestack" {
@@ -422,28 +400,6 @@ resource "azurestack_public_ip" "test" {
   allocation_method   = "Dynamic"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
-}
-
-func (PublicIPResource) dynamic_basic_withIPVersion(data acceptance.TestData, ipVersion string) string {
-	return fmt.Sprintf(`
-provider "azurestack" {
-  features {}
-}
-
-resource "azurestack_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurestack_public_ip" "test" {
-  name                = "acctestpublicip-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  allocation_method   = "Dynamic"
-
-  ip_version = "%s"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, ipVersion)
 }
 
 func (PublicIPResource) withTags(data acceptance.TestData) string {

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -75,39 +75,6 @@ func TestAccPublicIpStatic_basic_withDNSLabel(t *testing.T) {
 	})
 }
 
-func TestAccPublicIpStatic_standard_withIPv6(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_public_ip", "test")
-	r := PublicIPResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.standard_withIPVersion(data, "IPv6"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("ip_version").HasValue("IPv6"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccPublicIpDynamic_basic_withIPv6(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_public_ip", "test")
-	r := PublicIPResource{}
-	ipVersion := "Ipv6"
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.dynamic_basic_withIPVersion(data, ipVersion),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("ip_version").HasValue("IPv6"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccPublicIpStatic_basic_defaultsToIPv4(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurestack_public_ip", "test")
 	r := PublicIPResource{}
@@ -135,21 +102,6 @@ func TestAccPublicIpStatic_basic_withIPv4(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ip_version").HasValue("IPv4"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccPublicIpStatic_standard(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_public_ip", "test")
-	r := PublicIPResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.standard(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -388,27 +340,6 @@ resource "azurestack_public_ip" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, ipVersion)
 }
 
-func (PublicIPResource) standard(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurestack" {
-  features {}
-}
-
-resource "azurestack_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurestack_public_ip" "test" {
-  name                = "acctestpublicip-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
-}
-
 func (PublicIPResource) standard_withIPVersion(data acceptance.TestData, ipVersion string) string {
 	return fmt.Sprintf(`
 provider "azurestack" {
@@ -583,5 +514,5 @@ resource "azurestack_public_ip" "test" {
   allocation_method = "Static"
   domain_name_label = "%s"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomStringOfLength(63))
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomStringOfLength(62))
 }

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -103,8 +103,12 @@ output "public_ip_address" {
 
 ## Attributes Reference
 
+* `id` - The ID of the Public IP address.
+* `allocation_method` - The allocation method for this IP address..
 * `domain_name_label` - The label for the Domain Name.
 * `idle_timeout_in_minutes` - Specifies the timeout for the TCP idle connection.
 * `fqdn` - Fully qualified domain name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.
+* `reverse_fqdn` - A fully qualified domain name that resolves to this public IP address.
 * `ip_address` - The IP address value that was allocated.
+* `ip_version` - The IP version being used, for example `IPv4`.
 * `tags` - A mapping of tags to assigned to the resource.

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -19,10 +19,10 @@ resource "azurestack_resource_group" "test" {
 }
 
 resource "azurestack_public_ip" "test" {
-  name                         = "acceptanceTestPublicIp1"
-  location                     = "West US"
-  resource_group_name          = azurestack_resource_group.test.name
-  public_ip_address_allocation = "static"
+  name                = "acceptanceTestPublicIp1"
+  location            = "West US"
+  resource_group_name = azurestack_resource_group.test.name
+  allocation_method   = "static"
 
   tags = {
     environment = "Production"
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `public_ip_address_allocation` - (Required) Defines whether the IP address is static or dynamic. Options are Static or Dynamic.
+* `allocation_method` - (Required)  Defines the allocation method for this IP address. Possible values are `Static` or `Dynamic`.
 
 ~> **Note** `Dynamic` Public IP Addresses aren't allocated until they're assigned to a resource (such as a Virtual Machine or a Load Balancer) by design within Azure - [more information is available below](#ip_address).
 

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -42,7 +42,9 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `allocation_method` - (Required)  Defines the allocation method for this IP address. Possible values are `Static` or `Dynamic`.
+* `public_ip_address_allocation` - (Optional) Defines whether the IP address is static or dynamic. Options are Static or Dynamic. **Deprecated**, use `allocation_method`  instead.
+
+* `allocation_method` - (Optional)  Defines the allocation method for this IP address. Possible values are `Static` or `Dynamic`. 
 
 ~> **Note** `Dynamic` Public IP Addresses aren't allocated until they're assigned to a resource (such as a Virtual Machine or a Load Balancer) by design within Azure - [more information is available below](#ip_address).
 


### PR DESCRIPTION
- Removed value `Standard` for validation of parameter `Sku` because is not supported.
-  Removed parameter `public_ip_address_allocation` in favor of parameter `allocation_method`
-  Removed value IPv6 for validation because is not supported
-  Removed tests that involve Standard SKU or IPv6
- Updated docs for resource and datasource of Public IP