### PR TITLE
Removed unsupported parameters in network security group resource/datasource

### DIFF
--- a/internal/services/network/network_security_group_data_source.go
+++ b/internal/services/network/network_security_group_data_source.go
@@ -88,13 +88,6 @@ func networkSecurityGroupDataSource() *pluginsdk.Resource {
 							Set:      pluginsdk.HashString,
 						},
 
-						"source_application_security_group_ids": {
-							Type:     pluginsdk.TypeSet,
-							Optional: true,
-							Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
-							Set:      pluginsdk.HashString,
-						},
-
 						"destination_address_prefix": {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
@@ -103,13 +96,6 @@ func networkSecurityGroupDataSource() *pluginsdk.Resource {
 						"destination_address_prefixes": {
 							Type:     pluginsdk.TypeSet,
 							Computed: true,
-							Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
-							Set:      pluginsdk.HashString,
-						},
-
-						"destination_application_security_group_ids": {
-							Type:     pluginsdk.TypeSet,
-							Optional: true,
 							Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
 							Set:      pluginsdk.HashString,
 						},

--- a/internal/services/network/network_security_group_resource_test.go
+++ b/internal/services/network/network_security_group_resource_test.go
@@ -173,21 +173,6 @@ func TestAccNetworkSecurityGroup_augmented(t *testing.T) {
 	})
 }
 
-func TestAccNetworkSecurityGroup_applicationSecurityGroup(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_network_security_group", "test")
-	r := NetworkSecurityGroupResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.applicationSecurityGroup(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("security_rule.#").HasValue("1"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccNetworkSecurityGroup_deleteRule(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurestack_network_security_group", "test")
 	r := NetworkSecurityGroupResource{}
@@ -468,49 +453,6 @@ resource "azurestack_network_security_group" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
-}
-
-func (NetworkSecurityGroupResource) applicationSecurityGroup(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurestack" {
-  features {}
-}
-
-resource "azurestack_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurestack_application_security_group" "first" {
-  name                = "acctest-first%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-}
-
-resource "azurestack_application_security_group" "second" {
-  name                = "acctest-second%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-}
-
-resource "azurestack_network_security_group" "test" {
-  name                = "acctestnsg-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-
-  security_rule {
-    name                                       = "test123"
-    priority                                   = 100
-    direction                                  = "Inbound"
-    access                                     = "Allow"
-    protocol                                   = "Tcp"
-    source_application_security_group_ids      = [azurestack_application_security_group.first.id]
-    destination_application_security_group_ids = [azurestack_application_security_group.second.id]
-    source_port_ranges                         = ["10000-40000"]
-    destination_port_ranges                    = ["80", "443", "8080", "8190"]
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (NetworkSecurityGroupResource) deleteRule(data acceptance.TestData) string {


### PR DESCRIPTION
- Removed two unsupported parameters and its tests that uses it in resource/datasource of `azurestack_network_security_group`.