### PR TITLE
Removed unsupported parameters for Virtual Network Gateway

### DIFF
--- a/internal/services/network/virtual_network_gateway_data_source.go
+++ b/internal/services/network/virtual_network_gateway_data_source.go
@@ -101,16 +101,6 @@ func virtualNetworkGatewayDataSource() *pluginsdk.Resource {
 							},
 						},
 
-						"aad_audience": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
-						"aad_issuer": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-
 						"root_certificate": {
 							Type:     pluginsdk.TypeList,
 							Computed: true,

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -59,7 +59,6 @@ func virtualNetworkGateway() *pluginsdk.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(network.VirtualNetworkGatewayTypeExpressRoute),
 					string(network.VirtualNetworkGatewayTypeVpn),
 				}, true),
 			},
@@ -72,7 +71,6 @@ func virtualNetworkGateway() *pluginsdk.Resource {
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(network.RouteBased),
-					string(network.PolicyBased),
 				}, true),
 			},
 
@@ -98,9 +96,6 @@ func virtualNetworkGateway() *pluginsdk.Resource {
 				// and validateVirtualNetworkGatewayExpressRouteSku.
 				ValidateFunc: validation.Any(
 					validateVirtualNetworkGatewayPolicyBasedVpnSku(),
-					validateVirtualNetworkGatewayRouteBasedVpnSkuGeneration1(),
-					validateVirtualNetworkGatewayRouteBasedVpnSkuGeneration2(),
-					validateVirtualNetworkGatewayExpressRouteSku(),
 				),
 			},
 
@@ -148,6 +143,7 @@ func virtualNetworkGateway() *pluginsdk.Resource {
 			"vpn_client_configuration": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -217,6 +213,7 @@ func virtualNetworkGateway() *pluginsdk.Resource {
 								ValidateFunc: validation.StringInSlice([]string{
 									string(network.IkeV2),
 									string(network.SSTP),
+									string(network.OpenVPN),
 								}, true),
 							},
 						},
@@ -449,13 +446,6 @@ func getVirtualNetworkGatewayProperties(d *pluginsdk.ResourceData) (*network.Vir
 	// Sku validation for policy-based VPN gateways
 	if props.GatewayType == network.VirtualNetworkGatewayTypeVpn && props.VpnType == network.PolicyBased {
 		if ok, err := evaluateSchemaValidateFunc(string(props.Sku.Name), "sku", validateVirtualNetworkGatewayPolicyBasedVpnSku()); !ok {
-			return nil, err
-		}
-	}
-
-	// Sku validation for ExpressRoute gateways
-	if props.GatewayType == network.VirtualNetworkGatewayTypeExpressRoute {
-		if ok, err := evaluateSchemaValidateFunc(string(props.Sku.Name), "sku", validateVirtualNetworkGatewayExpressRouteSku()); !ok {
 			return nil, err
 		}
 	}
@@ -719,31 +709,7 @@ func hashVirtualNetworkGatewayRevokedCert(v interface{}) int {
 func validateVirtualNetworkGatewayPolicyBasedVpnSku() pluginsdk.SchemaValidateFunc {
 	return validation.StringInSlice([]string{
 		string(network.VirtualNetworkGatewaySkuTierBasic),
-	}, true)
-}
-
-func validateVirtualNetworkGatewayRouteBasedVpnSkuGeneration1() pluginsdk.SchemaValidateFunc {
-	return validation.StringInSlice([]string{
-		string(network.VirtualNetworkGatewaySkuTierBasic),
 		string(network.VirtualNetworkGatewaySkuTierStandard),
 		string(network.VirtualNetworkGatewaySkuTierHighPerformance),
-		string(network.VirtualNetworkGatewaySkuNameVpnGw1),
-		string(network.VirtualNetworkGatewaySkuNameVpnGw2),
-		string(network.VirtualNetworkGatewaySkuNameVpnGw3),
-	}, true)
-}
-
-func validateVirtualNetworkGatewayRouteBasedVpnSkuGeneration2() pluginsdk.SchemaValidateFunc {
-	return validation.StringInSlice([]string{
-		string(network.VirtualNetworkGatewaySkuNameVpnGw2),
-		string(network.VirtualNetworkGatewaySkuNameVpnGw3),
-	}, true)
-}
-
-func validateVirtualNetworkGatewayExpressRouteSku() pluginsdk.SchemaValidateFunc {
-	return validation.StringInSlice([]string{
-		string(network.VirtualNetworkGatewaySkuTierStandard),
-		string(network.VirtualNetworkGatewaySkuTierHighPerformance),
-		string(network.VirtualNetworkGatewaySkuTierUltraPerformance),
 	}, true)
 }

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -201,6 +201,7 @@ func virtualNetworkGateway() *pluginsdk.Resource {
 						"radius_server_secret": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
+							Sensitive:    true,
 							RequiredWith: []string{"vpn_client_configuration.0.radius_server_address"},
 						},
 
@@ -358,7 +359,7 @@ func virtualNetworkGatewayRead(d *pluginsdk.ResourceData, meta interface{}) erro
 			return fmt.Errorf("setting `ip_configuration`: %+v", err)
 		}
 
-		if err := d.Set("vpn_client_configuration", flattenVirtualNetworkGatewayVpnClientConfig(gw.VpnClientConfiguration)); err != nil {
+		if err := d.Set("vpn_client_configuration", flattenVirtualNetworkGatewayVpnClientConfig(d, gw.VpnClientConfiguration)); err != nil {
 			return fmt.Errorf("setting `vpn_client_configuration`: %+v", err)
 		}
 
@@ -631,7 +632,7 @@ func flattenVirtualNetworkGatewayIPConfigurations(ipConfigs *[]network.VirtualNe
 	return flat
 }
 
-func flattenVirtualNetworkGatewayVpnClientConfig(cfg *network.VpnClientConfiguration) []interface{} {
+func flattenVirtualNetworkGatewayVpnClientConfig(d *pluginsdk.ResourceData, cfg *network.VpnClientConfiguration) []interface{} {
 	if cfg == nil {
 		return []interface{}{}
 	}
@@ -680,7 +681,9 @@ func flattenVirtualNetworkGatewayVpnClientConfig(cfg *network.VpnClientConfigura
 	}
 
 	if v := cfg.RadiusServerSecret; v != nil {
-		flat["radius_server_secret"] = *v
+		if v1, ok := d.GetOk("vpn_client_configuration.0.radius_server_secret"); ok {
+			flat["radius_server_secret"] = v1.(string)
+		}
 	}
 
 	return []interface{}{flat}

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -64,20 +64,6 @@ func TestAccVirtualNetworkGateway_lowerCaseSubnetName(t *testing.T) {
 	})
 }
 
-func TestAccVirtualNetworkGateway_vpnGw1(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_virtual_network_gateway", "test")
-	r := VirtualNetworkGatewayResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.vpnGw1(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-	})
-}
-
 func TestAccVirtualNetworkGateway_activeActive(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurestack_virtual_network_gateway", "test")
 	r := VirtualNetworkGatewayResource{}
@@ -107,37 +93,7 @@ func TestAccVirtualNetworkGateway_standard(t *testing.T) {
 	})
 }
 
-func TestAccVirtualNetworkGateway_vpnGw2(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_virtual_network_gateway", "test")
-	r := VirtualNetworkGatewayResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.sku(data, "VpnGw2"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("VpnGw2"),
-			),
-		},
-	})
-}
-
-func TestAccVirtualNetworkGateway_vpnGw3(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_virtual_network_gateway", "test")
-	r := VirtualNetworkGatewayResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.sku(data, "VpnGw3"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("VpnGw3"),
-			),
-		},
-	})
-}
-
-func TestAccVirtualNetworkGateway_vpnClientConfig(t *testing.T) {
+func TestAccVirtualNetworkGateway_vpnClientConfig2(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurestack_virtual_network_gateway", "test")
 	r := VirtualNetworkGatewayResource{}
 
@@ -149,6 +105,7 @@ func TestAccVirtualNetworkGateway_vpnClientConfig(t *testing.T) {
 				check.That(data.ResourceName).Key("vpn_client_configuration.0.radius_server_address").HasValue("1.2.3.4"),
 				check.That(data.ResourceName).Key("vpn_client_configuration.0.vpn_client_protocols.#").HasValue("2"),
 			),
+			ExpectNonEmptyPlan: true,
 		},
 	})
 }
@@ -165,44 +122,6 @@ func TestAccVirtualNetworkGateway_vpnClientConfigOpenVPN(t *testing.T) {
 				check.That(data.ResourceName).Key("vpn_client_configuration.0.vpn_client_protocols.#").HasValue("1"),
 			),
 		},
-	})
-}
-
-func TestAccVirtualNetworkGateway_expressRoute(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_virtual_network_gateway", "test")
-	r := VirtualNetworkGatewayResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.expressRoute(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("type").HasValue("ExpressRoute"),
-				check.That(data.ResourceName).Key("bgp_settings.#").HasValue("0"),
-			),
-		},
-	})
-}
-
-func TestAccVirtualNetworkGateway_privateIpAddressEnabled(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_virtual_network_gateway", "test")
-	r := VirtualNetworkGatewayResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.privateIpAddressEnabled(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.privateIpAddressEnabledUpdate(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -339,56 +258,6 @@ resource "azurestack_virtual_network_gateway" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (VirtualNetworkGatewayResource) vpnGw1(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurestack" {
-  features {}
-}
-
-resource "azurestack_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurestack_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurestack_subnet" "test" {
-  name                 = "GatewaySubnet"
-  resource_group_name  = azurestack_resource_group.test.name
-  virtual_network_name = azurestack_virtual_network.test.name
-  address_prefix       = "10.0.1.0/24"
-}
-
-resource "azurestack_public_ip" "test" {
-  name                = "acctestpip-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  allocation_method   = "Dynamic"
-}
-
-resource "azurestack_virtual_network_gateway" "test" {
-  name                = "acctestvng-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-
-  type     = "Vpn"
-  vpn_type = "RouteBased"
-  sku      = "VpnGw1"
-
-  ip_configuration {
-    public_ip_address_id          = azurestack_public_ip.test.id
-    private_ip_address_allocation = "Dynamic"
-    subnet_id                     = azurestack_subnet.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
 func (VirtualNetworkGatewayResource) activeActive(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurestack" {
@@ -440,7 +309,7 @@ resource "azurestack_virtual_network_gateway" "test" {
 
   type     = "Vpn"
   vpn_type = "RouteBased"
-  sku      = "VpnGw1"
+  sku      = "HighPerformance"
 
   active_active = true
   enable_bgp    = true
@@ -507,7 +376,7 @@ resource "azurestack_virtual_network_gateway" "test" {
 
   type     = "Vpn"
   vpn_type = "RouteBased"
-  sku      = "VpnGw1"
+  sku      = "Standard"
 
   ip_configuration {
     public_ip_address_id          = azurestack_public_ip.test.id
@@ -566,7 +435,7 @@ resource "azurestack_virtual_network_gateway" "test" {
 
   type     = "Vpn"
   vpn_type = "RouteBased"
-  sku      = "VpnGw1"
+  sku      = "Standard"
 
   ip_configuration {
     public_ip_address_id          = azurestack_public_ip.test.id
@@ -630,152 +499,4 @@ resource "azurestack_virtual_network_gateway" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, sku)
-}
-
-func (VirtualNetworkGatewayResource) expressRoute(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurestack" {
-  features {}
-}
-
-resource "azurestack_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurestack_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurestack_subnet" "test" {
-  name                 = "GatewaySubnet"
-  resource_group_name  = azurestack_resource_group.test.name
-  virtual_network_name = azurestack_virtual_network.test.name
-  address_prefix       = "10.0.1.0/24"
-}
-
-resource "azurestack_public_ip" "test" {
-  name                = "acctestpip1-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  allocation_method   = "Dynamic"
-}
-
-resource "azurestack_virtual_network_gateway" "test" {
-  name                = "acctestvng-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-
-  type     = "ExpressRoute"
-  vpn_type = "PolicyBased"
-  sku      = "Standard"
-
-  ip_configuration {
-    public_ip_address_id          = azurestack_public_ip.test.id
-    private_ip_address_allocation = "Dynamic"
-    subnet_id                     = azurestack_subnet.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func (VirtualNetworkGatewayResource) privateIpAddressEnabled(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-resource "azurestack_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurestack_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurestack_subnet" "test" {
-  name                 = "GatewaySubnet"
-  resource_group_name  = azurestack_resource_group.test.name
-  virtual_network_name = azurestack_virtual_network.test.name
-  address_prefix       = "10.0.1.0/24"
-}
-
-resource "azurestack_public_ip" "test" {
-  name                = "acctest-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurestack_virtual_network_gateway" "test" {
-  name                = "acctest-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-
-  type                       = "Vpn"
-  vpn_type                   = "RouteBased"
-  sku                        = "VpnGw1AZ"
-  private_ip_address_enabled = true
-
-  ip_configuration {
-    name                          = "vnetGatewayConfig"
-    public_ip_address_id          = azurestack_public_ip.test.id
-    private_ip_address_allocation = "Dynamic"
-    subnet_id                     = azurestack_subnet.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func (VirtualNetworkGatewayResource) privateIpAddressEnabledUpdate(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-resource "azurestack_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurestack_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurestack_subnet" "test" {
-  name                 = "GatewaySubnet"
-  resource_group_name  = azurestack_resource_group.test.name
-  virtual_network_name = azurestack_virtual_network.test.name
-  address_prefix       = "10.0.1.0/24"
-}
-
-resource "azurestack_public_ip" "test" {
-  name                = "acctest-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurestack_virtual_network_gateway" "test" {
-  name                = "acctest-%d"
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-
-  type                       = "Vpn"
-  vpn_type                   = "RouteBased"
-  sku                        = "VpnGw1AZ"
-  private_ip_address_enabled = false
-
-  ip_configuration {
-    name                          = "vnetGatewayConfig"
-    public_ip_address_id          = azurestack_public_ip.test.id
-    private_ip_address_allocation = "Dynamic"
-    subnet_id                     = azurestack_subnet.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -105,7 +105,6 @@ func TestAccVirtualNetworkGateway_vpnClientConfig(t *testing.T) {
 				check.That(data.ResourceName).Key("vpn_client_configuration.0.radius_server_address").HasValue("1.2.3.4"),
 				check.That(data.ResourceName).Key("vpn_client_configuration.0.vpn_client_protocols.#").HasValue("2"),
 			),
-			ExpectNonEmptyPlan: true,
 		},
 	})
 }

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -93,7 +93,7 @@ func TestAccVirtualNetworkGateway_standard(t *testing.T) {
 	})
 }
 
-func TestAccVirtualNetworkGateway_vpnClientConfig2(t *testing.T) {
+func TestAccVirtualNetworkGateway_vpnClientConfig(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurestack_virtual_network_gateway", "test")
 	r := VirtualNetworkGatewayResource{}
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -76,6 +76,10 @@ The following arguments are supported:
 
 * `ip_configuration` - (Required) One or two ip_configuration blocks documented below. An active-standby gateway requires exactly one ip_configuration block whereas an active-active gateway requires exactly two ip_configuration blocks.
 
+* `vpn_client_configuration` (Optional) A `vpn_client_configuration` block which
+  is documented below. In this block the Virtual Network Gateway can be configured
+  to accept IPSec point-to-site connections.
+* 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `ip_configuration` block supports:
@@ -88,12 +92,50 @@ The `ip_configuration` block supports:
 
 * `public_ip_address_id` - (Optional) The ID of the public ip address to associate with the Virtual Network Gateway.
 
+The `vpn_client_configuration` block supports:
+
+* `address_space` - (Required) The address space out of which ip addresses for
+  vpn clients will be taken. You can provide more than one address space, e.g.
+  in CIDR notation.
+
+* `root_certificate` - (Optional) One or more `root_certificate` blocks which are
+  defined below. These root certificates are used to sign the client certificate
+  used by the VPN clients to connect to the gateway.
+
+* `revoked_certificate` - (Optional) One or more `revoked_certificate` blocks which
+  are defined below.
+
+* `radius_server_address` - (Optional) The address of the Radius server.
+
+* `radius_server_secret` - (Optional) The secret used by the Radius server.
+
+* `vpn_client_protocols` - (Optional) List of the protocols supported by the vpn client.
+  The supported values are `SSTP`, `IkeV2` and `OpenVPN`.
+
 The `bgp_settings` block supports:
 
 * `asn` - (Optional) The Autonomous System Number (ASN) to use as part of the BGP.
 
 * `peering_address` - (Optional) The BGP peer IP address of the virtual network gateway. This address is needed to configure the created gateway as a BGP Peer on the on-premises VPN devices. The IP address must be part of the subnet of the Virtual Network Gateway. Changing this forces a new resource to be created
 
+
+The `root_certificate` block supports:
+
+* `name` - (Required) A user-defined name of the root certificate.
+
+* `public_cert_data` - (Required) The public certificate of the root certificate
+  authority. The certificate must be provided in Base-64 encoded X.509 format
+  (PEM). In particular, this argument *must not* include the
+  `-----BEGIN CERTIFICATE-----` or `-----END CERTIFICATE-----` markers.
+
+---
+
+The `revoked_certificate` block supports:
+
+* `name` - (Required) A user-defined name of the revoked certificate.
+
+* `thumbprint` - (Required) The SHA1 thumbprint of the certificate to be
+  revoked.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Removed some parameters, functions that are not supported
- Fixes a bug about detecting a difference after terraform plan for parameter `radius_server_secret`
- Fixes some values in testing because of type not being supported.
- Updated docs