### PR TITLE
New resources for Linux and Windows Virtual Machine Scale Set

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -11,5 +11,10 @@ func Default() UserFeatures {
 			GracefulShutdown:           false,
 			SkipShutdownAndForceDelete: false,
 		},
+		VirtualMachineScaleSet: VirtualMachineScaleSetFeatures{
+			ForceDelete:               false,
+			RollInstancesWhenRequired: true,
+			ScaleToZeroOnDelete:       true,
+		},
 	}
 }

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -1,8 +1,9 @@
 package features
 
 type UserFeatures struct {
-	ResourceGroup  ResourceGroupFeatures
-	VirtualMachine VirtualMachineFeatures
+	ResourceGroup          ResourceGroupFeatures
+	VirtualMachine         VirtualMachineFeatures
+	VirtualMachineScaleSet VirtualMachineScaleSetFeatures
 }
 
 type ResourceGroupFeatures struct {
@@ -13,4 +14,10 @@ type VirtualMachineFeatures struct {
 	DeleteOSDiskOnDeletion     bool
 	GracefulShutdown           bool
 	SkipShutdownAndForceDelete bool
+}
+
+type VirtualMachineScaleSetFeatures struct {
+	ForceDelete               bool
+	RollInstancesWhenRequired bool
+	ScaleToZeroOnDelete       bool
 }

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -31,6 +31,31 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 				},
 			},
 		},
+
+		"virtual_machine_scale_set": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"force_delete": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+					"roll_instances_when_required": {
+						Type:     pluginsdk.TypeBool,
+						Required: true,
+					},
+					"scale_to_zero_before_deletion": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+				},
+			},
+		},
+
 		"resource_group": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
@@ -91,6 +116,22 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			}
 			if v, ok := virtualMachinesRaw["skip_shutdown_and_force_delete"]; ok {
 				featuresMap.VirtualMachine.SkipShutdownAndForceDelete = v.(bool)
+			}
+		}
+	}
+
+	if raw, ok := val["virtual_machine_scale_set"]; ok {
+		items := raw.([]interface{})
+		if len(items) > 0 {
+			scaleSetRaw := items[0].(map[string]interface{})
+			if v, ok := scaleSetRaw["roll_instances_when_required"]; ok {
+				featuresMap.VirtualMachineScaleSet.RollInstancesWhenRequired = v.(bool)
+			}
+			if v, ok := scaleSetRaw["force_delete"]; ok {
+				featuresMap.VirtualMachineScaleSet.ForceDelete = v.(bool)
+			}
+			if v, ok := scaleSetRaw["scale_to_zero_before_deletion"]; ok {
+				featuresMap.VirtualMachineScaleSet.ScaleToZeroOnDelete = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -23,6 +23,11 @@ func TestExpandFeatures(t *testing.T) {
 					GracefulShutdown:           false,
 					SkipShutdownAndForceDelete: false,
 				},
+				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
+					ForceDelete:               false,
+					RollInstancesWhenRequired: true,
+					ScaleToZeroOnDelete:       true,
+				},
 				ResourceGroup: features.ResourceGroupFeatures{
 					PreventDeletionIfContainsResources: false,
 				},
@@ -67,6 +72,11 @@ func TestExpandFeatures(t *testing.T) {
 					GracefulShutdown:           true,
 					SkipShutdownAndForceDelete: true,
 				},
+				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
+					RollInstancesWhenRequired: true,
+					ForceDelete:               true,
+					ScaleToZeroOnDelete:       true,
+				},
 			},
 		},
 		{
@@ -107,6 +117,11 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteOSDiskOnDeletion:     false,
 					GracefulShutdown:           false,
 					SkipShutdownAndForceDelete: false,
+				},
+				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
+					ForceDelete:               false,
+					RollInstancesWhenRequired: false,
+					ScaleToZeroOnDelete:       false,
 				},
 			},
 		},
@@ -300,6 +315,120 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.VirtualMachine, testCase.Expected.VirtualMachine) {
 			t.Fatalf("Expected %+v but got %+v", result.VirtualMachine, testCase.Expected.VirtualMachine)
+		}
+	}
+}
+
+func TestExpandFeaturesVirtualMachineScaleSet(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    []interface{}
+		EnvVars  map[string]interface{}
+		Expected features.UserFeatures
+	}{
+		{
+			Name: "Empty Block",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine_scale_set": []interface{}{},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
+					RollInstancesWhenRequired: true,
+					ScaleToZeroOnDelete:       true,
+				},
+			},
+		},
+		{
+			Name: "Force Delete Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine_scale_set": []interface{}{
+						map[string]interface{}{
+							"force_delete":                 true,
+							"roll_instances_when_required": false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
+					ForceDelete:               true,
+					RollInstancesWhenRequired: false,
+					ScaleToZeroOnDelete:       true,
+				},
+			},
+		},
+		{
+			Name: "Roll Instances Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine_scale_set": []interface{}{
+						map[string]interface{}{
+							"force_delete":                 false,
+							"roll_instances_when_required": true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
+					ForceDelete:               false,
+					RollInstancesWhenRequired: true,
+					ScaleToZeroOnDelete:       true,
+				},
+			},
+		},
+		{
+			Name: "Scale In On Delete Disabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine_scale_set": []interface{}{
+						map[string]interface{}{
+							"force_delete":                  false,
+							"roll_instances_when_required":  true,
+							"scale_to_zero_before_deletion": false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
+					ForceDelete:               false,
+					RollInstancesWhenRequired: true,
+					ScaleToZeroOnDelete:       false,
+				},
+			},
+		},
+		{
+			Name: "All Fields Disabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine_scale_set": []interface{}{
+						map[string]interface{}{
+							"force_delete":                  false,
+							"roll_instances_when_required":  false,
+							"scale_to_zero_before_deletion": false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
+					ForceDelete:               false,
+					RollInstancesWhenRequired: false,
+					ScaleToZeroOnDelete:       false,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
+		result := expandFeatures(testCase.Input)
+		if !reflect.DeepEqual(result.VirtualMachineScaleSet, testCase.Expected.VirtualMachineScaleSet) {
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.VirtualMachineScaleSet, result.VirtualMachineScaleSet)
 		}
 	}
 }

--- a/internal/services/compute/helpers.go
+++ b/internal/services/compute/helpers.go
@@ -1,0 +1,35 @@
+package compute
+
+import (
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/utils"
+)
+
+func expandIDsToSubResources(input []interface{}) *[]compute.SubResource {
+	ids := make([]compute.SubResource, 0)
+
+	for _, v := range input {
+		ids = append(ids, compute.SubResource{
+			ID: utils.String(v.(string)),
+		})
+	}
+
+	return &ids
+}
+
+func flattenSubResourcesToIDs(input *[]compute.SubResource) []interface{} {
+	ids := make([]interface{}, 0)
+	if input == nil {
+		return ids
+	}
+
+	for _, v := range *input {
+		if v.ID == nil {
+			continue
+		}
+
+		ids = append(ids, *v.ID)
+	}
+
+	return ids
+}

--- a/internal/services/compute/linux_virtual_machine_scale_set_auth_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_auth_resource_test.go
@@ -1,0 +1,342 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+)
+
+func TestAccLinuxVirtualMachineScaleSet_authPassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authPassword(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_authSSHKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authSSHKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_authSSHKeyAndPassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authSSHKeyAndPassword(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_authMultipleSSHKeys(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authMultipleSSHKeys(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_authUpdatingSSHKeys(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authSSHKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authSSHKeyUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_authDisablePasswordAuthUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// disable it
+			Config: r.authSSHKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// enable it
+			Config: r.authPassword(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// disable it
+			Config: r.authSSHKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r LinuxVirtualMachineScaleSetResource) authPassword(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) authSSHKey(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) authSSHKeyUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.second_public_key
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) authSSHKeyAndPassword(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) authMultipleSSHKeys(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.second_public_key
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}

--- a/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_disk_data_resource_test.go
@@ -1,0 +1,577 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+)
+
+func TestAccLinuxVirtualMachineScaleSet_disksDataDiskBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksDataDiskBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksDataDiskCaching(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksDataDiskCaching(data, "None"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.disksDataDiskCaching(data, "ReadOnly"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.disksDataDiskCaching(data, "ReadWrite"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksDataDiskResizing(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// 30GB
+			Config: r.disksDataDiskResize(data, 30),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// 60GB
+			Config: r.disksDataDiskResize(data, 60),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksDataDiskMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksDataDiskMultiple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksDataDiskRemove(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksDataDiskBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.authPassword(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksDataDiskScaling(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// no disks
+			Config: r.authPassword(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// one disk
+			Config: r.disksDataDiskBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// two disks
+			Config: r.disksDataDiskMultiple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// no disks
+			Config: r.authPassword(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksDataDiskStorageAccountType(data, "Standard_LRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksDataDiskStorageAccountType(data, "Premium_LRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksDataDiskWriteAcceleratorEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksDataDiskBasic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  data_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+    disk_size_gb         = 10
+    lun                  = 10
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksDataDiskCaching(data acceptance.TestData, caching string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  data_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = %q
+    disk_size_gb         = 10
+    lun                  = 10
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, caching)
+}
+
+func (LinuxVirtualMachineScaleSetResource) disksDataDisk_diskEncryptionSetDependencies(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurestack" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = false
+      purge_soft_delete_on_destroy    = false
+    }
+  }
+}
+
+data "azurestack_client_config" "current" {}
+
+resource "azurestack_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurestack_key_vault" "test" {
+  name                        = "acctestkv%s"
+  location                    = azurestack_resource_group.test.location
+  resource_group_name         = azurestack_resource_group.test.name
+  tenant_id                   = data.azurestack_client_config.current.tenant_id
+  sku_name                    = "standard"
+  purge_protection_enabled    = true
+  enabled_for_disk_encryption = true
+}
+
+resource "azurestack_key_vault_access_policy" "service-principal" {
+  key_vault_id = azurestack_key_vault.test.id
+  tenant_id    = data.azurestack_client_config.current.tenant_id
+  object_id    = data.azurestack_client_config.current.object_id
+
+  key_permissions = [
+    "Create",
+    "Delete",
+    "Get",
+    "Purge",
+    "Update",
+  ]
+
+  secret_permissions = [
+    "Get",
+    "Delete",
+    "Set",
+  ]
+}
+
+resource "azurestack_key_vault_key" "test" {
+  name         = "examplekey"
+  key_vault_id = azurestack_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "Decrypt",
+    "Encrypt",
+    "Sign",
+    "UnwrapKey",
+    "Verify",
+    "WrapKey",
+  ]
+
+  depends_on = ["azurestack_key_vault_access_policy.service-principal"]
+}
+
+resource "azurestack_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+}
+
+resource "azurestack_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurestack_resource_group.test.name
+  virtual_network_name = azurestack_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksDataDiskResize(data acceptance.TestData, diskSizeGb int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  data_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+    lun                  = 10
+    disk_size_gb         = %d
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, diskSizeGb)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksDataDiskMultiple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  data_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+    disk_size_gb         = 10
+    lun                  = 10
+  }
+
+  data_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+    disk_size_gb         = 10
+    lun                  = 20
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksDataDiskStorageAccountType(data acceptance.TestData, storageAccountType string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2s_v2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  data_disk {
+    storage_account_type = %q
+    caching              = "None"
+    disk_size_gb         = 10
+    lun                  = 10
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, storageAccountType)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksDataDiskWriteAcceleratorEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_DS14_v2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Premium_LRS"
+    caching              = "None"
+  }
+
+  data_disk {
+    storage_account_type      = "Premium_LRS"
+    caching                   = "None"
+    disk_size_gb              = 10
+    lun                       = 10
+    write_accelerator_enabled = true
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}

--- a/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
@@ -1,0 +1,336 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+)
+
+func TestAccLinuxVirtualMachineScaleSet_disksOSDiskCaching(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskCaching(data, "None"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.disksOSDiskCaching(data, "ReadOnly"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.disksOSDiskCaching(data, "ReadWrite"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksOSDiskCustomSize(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// unset
+			Config: r.authPassword(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.disksOSDiskCustomSize(data, 30),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// resize a second time to confirm https://github.com/Azure/azure-rest-api-specs/issues/1906
+			Config: r.disksOSDiskCustomSize(data, 60),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksOSDiskEphemeral(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskEphemeral(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskStorageAccountType(data, "Standard_LRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskStorageAccountType(data, "Premium_LRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskWriteAcceleratorEnabled(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksOSDiskCaching(data acceptance.TestData, caching string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "%s"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, caching)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksOSDiskCustomSize(data acceptance.TestData, diskSize int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+    disk_size_gb         = %d
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, diskSize)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksOSDiskEphemeral(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2s_v2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadOnly"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksOSDiskStorageAccountType(data acceptance.TestData, storageAccountType string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2s_v2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = %q
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, storageAccountType)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) disksOSDiskWriteAcceleratorEnabled(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_DS14_v2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type      = "Premium_LRS"
+    caching                   = "None"
+    write_accelerator_enabled = %t
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, enabled)
+}

--- a/internal/services/compute/linux_virtual_machine_scale_set_extensions_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_extensions_test.go
@@ -1,0 +1,515 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+)
+
+func TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachines(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionDoNotRunExtensionsOnOverProvisionedMachines(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachinesUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionDoNotRunExtensionsOnOverProvisionedMachines(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.extensionDoNotRunExtensionsOnOverProvisionedMachines(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.extensionDoNotRunExtensionsOnOverProvisionedMachines(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_extensionBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password", "extension.0.protected_settings"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_extensionOnlySettings(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionOnlySettings(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password", "extension.0.protected_settings"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_extensionForceUpdateTag(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionForceUpdateTag(data, "first"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		{
+			Config: r.extensionForceUpdateTag(data, "second"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password", "extension.0.protected_settings"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_extensionsMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionMultiple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password", "extension.0.protected_settings", "extension.1.protected_settings"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_extensionsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		{
+			Config: r.extensionUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password", "extension.0.protected_settings"),
+		{
+			Config: r.extensionBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password", "extension.0.protected_settings"),
+	})
+}
+
+func (r LinuxVirtualMachineScaleSetResource) extensionDoNotRunExtensionsOnOverProvisionedMachines(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+  overprovision       = true
+
+  disable_password_authentication                   = false
+  do_not_run_extensions_on_overprovisioned_machines = %t
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, enabled)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) extensionOnlySettings(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurestack" {
+  features {}
+}
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    settings = jsonencode({
+      "commandToExecute" = "echo $HOSTNAME"
+    })
+
+  }
+
+  tags = {
+    accTest = "true"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) extensionBasic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurestack" {
+  features {}
+}
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    settings = jsonencode({
+      "commandToExecute" = "echo $HOSTNAME"
+    })
+
+  }
+
+  tags = {
+    accTest = "true"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) extensionForceUpdateTag(data acceptance.TestData, updateTag string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurestack" {
+  features {}
+}
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+    force_update_tag           = %q
+
+    settings = jsonencode({
+      "commandToExecute" = "echo $HOSTNAME"
+    })
+  }
+
+  tags = {
+    accTest = "true"
+  }
+}
+`, r.template(data), data.RandomInteger, updateTag)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) extensionMultiple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurestack" {
+  features {}
+}
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    provision_after_extensions = ["VMAccessForLinux"]
+
+    settings = jsonencode({
+      "commandToExecute" = "echo $HOSTNAME"
+    })
+  }
+
+  extension {
+    name                       = "VMAccessForLinux"
+    publisher                  = "Microsoft.OSTCExtensions"
+    type                       = "VMAccessForLinux"
+    type_handler_version       = "1.5"
+    auto_upgrade_minor_version = true
+
+    protected_settings = jsonencode({
+      "reset_ssh" = "True"
+    })
+
+  }
+
+  tags = {
+    accTest = "true"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) extensionUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurestack" {
+  features {}
+}
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    settings = jsonencode({
+      "commandToExecute" = "echo $(date)"
+    })
+  }
+
+  tags = {
+    accTest = "true"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}

--- a/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_network_resource_test.go
@@ -1,0 +1,757 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+)
+
+func TestAccLinuxVirtualMachineScaleSet_networkDNSServers(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkDNSServers(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.networkDNSServersUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_networkIPForwarding(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// enabled
+			Config: r.networkIPForwarding(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// disabled
+			Config: r.networkPrivate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// enabled
+			Config: r.networkIPForwarding(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_networkLoadBalancer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkLoadBalancer(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_networkMultipleIPConfigurations(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkMultipleIPConfigurations(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_networkMultipleNICs(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkMultipleNICs(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkMultipleNICsMultipleIPConfigurations(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkMultipleNICsWithDifferentDNSServers(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkNetworkSecurityGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// without
+			Config: r.networkPrivate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// add one
+			Config: r.networkNetworkSecurityGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// change it
+			Config: r.networkNetworkSecurityGroupUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccLinuxVirtualMachineScaleSet_networkPrivate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkPrivate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkDNSServers(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name        = "example"
+    primary     = true
+    dns_servers = ["8.8.8.8"]
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkDNSServersUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name        = "example"
+    primary     = true
+    dns_servers = ["1.1.1.1", "8.8.8.8"]
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkIPForwarding(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name                 = "example"
+    primary              = true
+    enable_ip_forwarding = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkLoadBalancer(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_public_ip" "test" {
+  name                = "test-ip-%d"
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+  allocation_method   = "Static"
+}
+
+resource "azurestack_lb" "test" {
+  name                = "acctestlb-%d"
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+
+  frontend_ip_configuration {
+    name                 = "internal"
+    public_ip_address_id = azurestack_public_ip.test.id
+  }
+}
+
+resource "azurestack_lb_backend_address_pool" "test" {
+  name            = "test"
+  loadbalancer_id = azurestack_lb.test.id
+}
+
+resource "azurestack_lb_nat_pool" "test" {
+  name                           = "test"
+  resource_group_name            = azurestack_resource_group.test.name
+  loadbalancer_id                = azurestack_lb.test.id
+  frontend_ip_configuration_name = "internal"
+  protocol                       = "Tcp"
+  frontend_port_start            = 80
+  frontend_port_end              = 81
+  backend_port                   = 8080
+}
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name                                   = "internal"
+      primary                                = true
+      subnet_id                              = azurestack_subnet.test.id
+      load_balancer_backend_address_pool_ids = [azurestack_lb_backend_address_pool.test.id]
+      load_balancer_inbound_nat_rules_ids    = [azurestack_lb_nat_pool.test.id]
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkMultipleIPConfigurations(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "internal"
+    primary = true
+
+    ip_configuration {
+      name      = "primary"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+
+    ip_configuration {
+      name      = "secondary"
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkMultipleNICs(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "primary"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  network_interface {
+    name = "secondary"
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkMultipleNICsMultipleIPConfigurations(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "primary"
+    primary = true
+
+    ip_configuration {
+      name      = "first"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+
+    ip_configuration {
+      name      = "second"
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  network_interface {
+    name = "secondary"
+
+    ip_configuration {
+      name      = "third"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+
+    ip_configuration {
+      name      = "fourth"
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkMultipleNICsWithDifferentDNSServers(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name        = "primary"
+    primary     = true
+    dns_servers = ["8.8.8.8"]
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  network_interface {
+    name        = "secondary"
+    dns_servers = ["1.1.1.1"]
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkNetworkSecurityGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = "${azurestack_resource_group.test.location}"
+  resource_group_name = "${azurestack_resource_group.test.name}"
+}
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name                      = "example"
+    primary                   = true
+    network_security_group_id = azurestack_network_security_group.test.id
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkNetworkSecurityGroupUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = "${azurestack_resource_group.test.location}"
+  resource_group_name = "${azurestack_resource_group.test.name}"
+}
+
+resource "azurestack_network_security_group" "other" {
+  name                = "acctestnsg2-%d"
+  location            = "${azurestack_resource_group.test.location}"
+  resource_group_name = "${azurestack_resource_group.test.name}"
+}
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name                      = "example"
+    primary                   = true
+    network_security_group_id = azurestack_network_security_group.other.id
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) networkPrivate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -1,0 +1,938 @@
+package compute
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/az/resourceid"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/az/tags"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/validate"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/base64"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/timeouts"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/utils"
+)
+
+func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceLinuxVirtualMachineScaleSetCreate,
+		Read:   resourceLinuxVirtualMachineScaleSetRead,
+		Update: resourceLinuxVirtualMachineScaleSetUpdate,
+		Delete: resourceLinuxVirtualMachineScaleSetDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
+			_, err := parse.VirtualMachineScaleSetID(id)
+			return err
+		}, importVirtualMachineScaleSet(compute.Linux, "azurestack_linux_virtual_machine_scale_set")),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(time.Minute * 60),
+			Read:   pluginsdk.DefaultTimeout(time.Minute * 5),
+			Update: pluginsdk.DefaultTimeout(time.Minute * 60),
+			Delete: pluginsdk.DefaultTimeout(time.Minute * 60),
+		},
+
+		// TODO: exposing requireGuestProvisionSignal once it's available
+		// https://github.com/Azure/azure-rest-api-specs/pull/7246
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.VirtualMachineName,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"location": commonschema.Location(),
+
+			// Required
+			"admin_username": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"network_interface": VirtualMachineScaleSetNetworkInterfaceSchema(),
+
+			"os_disk": VirtualMachineScaleSetOSDiskSchema(),
+
+			"instances": {
+				Type:         pluginsdk.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+
+			"sku": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			// Optional
+			"additional_capabilities": VirtualMachineScaleSetAdditionalCapabilitiesSchema(),
+
+			"admin_password": {
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Sensitive:        true,
+				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
+			},
+
+			"admin_ssh_key": SSHKeysSchema(false),
+
+			"automatic_os_upgrade_policy": VirtualMachineScaleSetAutomatedOSUpgradePolicySchema(),
+
+			"automatic_instance_repair": VirtualMachineScaleSetAutomaticRepairsPolicySchema(),
+
+			"boot_diagnostics": bootDiagnosticsSchema(),
+
+			"computer_name_prefix": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+
+				// Computed since we reuse the VM name if one's not specified
+				Computed: true,
+				ForceNew: true,
+
+				ValidateFunc: validate.LinuxComputerNamePrefix,
+			},
+
+			"custom_data": base64.OptionalSchema(false),
+
+			"data_disk": VirtualMachineScaleSetDataDiskSchema(),
+
+			"disable_password_authentication": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"do_not_run_extensions_on_overprovisioned_machines": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"encryption_at_host_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"extension": VirtualMachineScaleSetExtensionsSchema(),
+
+			// TODO: Uncomment extensions_time_budget when it's fixed
+			/*"extensions_time_budget": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      "PT1H30M",
+				ValidateFunc: utils.ISO8601DurationBetween("PT15M", "PT2H"),
+			},*/
+
+			"health_probe_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: resourceid.ValidateResourceID,
+			},
+
+			"overprovision": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"plan": planSchema(),
+
+			"platform_fault_domain_count": {
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
+			"provision_vm_agent": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+
+			"secret": linuxSecretSchema(),
+
+			"single_placement_group": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"source_image_id": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.Any(
+					validate.ImageID,
+					validate.SharedImageID,
+					validate.SharedImageVersionID,
+				),
+			},
+
+			"source_image_reference": sourceImageReferenceSchema(false),
+
+			"tags": tags.Schema(),
+
+			"upgrade_mode": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  string(compute.UpgradeModeManual),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.UpgradeModeAutomatic),
+					string(compute.UpgradeModeManual),
+					string(compute.UpgradeModeRolling),
+				}, false),
+			},
+
+			"scale_in_policy": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(compute.Default),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.Default),
+					string(compute.NewestVM),
+					string(compute.OldestVM),
+				}, false),
+			},
+
+			"terminate_notification": VirtualMachineScaleSetTerminateNotificationSchema(),
+
+			// Computed
+			"unique_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+
+	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
+	exists, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(exists.Response) {
+			return fmt.Errorf("checking for existing Linux %s: %+v", id, err)
+		}
+	}
+
+	if !utils.ResponseWasNotFound(exists.Response) {
+		return tf.ImportAsExistsError("azurestack_linux_virtual_machine_scale_set", *exists.ID)
+	}
+
+	location := location.Normalize(d.Get("location").(string))
+	t := d.Get("tags").(map[string]interface{})
+
+	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
+	additionalCapabilities := ExpandVirtualMachineScaleSetAdditionalCapabilities(additionalCapabilitiesRaw)
+
+	bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
+	bootDiagnostics := expandBootDiagnostics(bootDiagnosticsRaw)
+
+	dataDisksRaw := d.Get("data_disk").([]interface{})
+	ultraSSDEnabled := d.Get("additional_capabilities.0.ultra_ssd_enabled").(bool)
+	dataDisks, err := ExpandVirtualMachineScaleSetDataDisk(dataDisksRaw, ultraSSDEnabled)
+	if err != nil {
+		return fmt.Errorf("expanding `data_disk`: %+v", err)
+	}
+
+	networkInterfacesRaw := d.Get("network_interface").([]interface{})
+	networkInterfaces, err := ExpandVirtualMachineScaleSetNetworkInterface(networkInterfacesRaw)
+	if err != nil {
+		return fmt.Errorf("expanding `network_interface`: %+v", err)
+	}
+
+	osDiskRaw := d.Get("os_disk").([]interface{})
+	osDisk := ExpandVirtualMachineScaleSetOSDisk(osDiskRaw, compute.Linux)
+
+	planRaw := d.Get("plan").([]interface{})
+	plan := expandPlan(planRaw)
+
+	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
+	sourceImageId := d.Get("source_image_id").(string)
+	sourceImageReference, err := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+	if err != nil {
+		return err
+	}
+
+	sshKeysRaw := d.Get("admin_ssh_key").(*pluginsdk.Set).List()
+	sshKeys := ExpandSSHKeys(sshKeysRaw)
+
+	healthProbeId := d.Get("health_probe_id").(string)
+	upgradeMode := compute.UpgradeMode(d.Get("upgrade_mode").(string))
+	automaticOSUpgradePolicyRaw := d.Get("automatic_os_upgrade_policy").([]interface{})
+	automaticOSUpgradePolicy := ExpandVirtualMachineScaleSetAutomaticUpgradePolicy(automaticOSUpgradePolicyRaw)
+
+	if upgradeMode != compute.UpgradeModeAutomatic && len(automaticOSUpgradePolicyRaw) > 0 {
+		return fmt.Errorf("an `automatic_os_upgrade_policy` block cannot be specified when `upgrade_mode` is not set to `Automatic`")
+	}
+
+	secretsRaw := d.Get("secret").([]interface{})
+	secrets := expandLinuxSecrets(secretsRaw)
+
+	var computerNamePrefix string
+	if v, ok := d.GetOk("computer_name_prefix"); ok && len(v.(string)) > 0 {
+		computerNamePrefix = v.(string)
+	} else {
+		_, errs := validate.LinuxComputerNamePrefix(d.Get("name"), "computer_name_prefix")
+		if len(errs) > 0 {
+			return fmt.Errorf("unable to assume default computer name prefix %s. Please adjust the %q, or specify an explicit %q", errs[0], "name", "computer_name_prefix")
+		}
+		computerNamePrefix = id.Name
+	}
+
+	disablePasswordAuthentication := d.Get("disable_password_authentication").(bool)
+	networkProfile := &compute.VirtualMachineScaleSetNetworkProfile{
+		NetworkInterfaceConfigurations: networkInterfaces,
+	}
+	if healthProbeId != "" {
+		networkProfile.HealthProbe = &compute.APIEntityReference{
+			ID: utils.String(healthProbeId),
+		}
+	}
+
+	upgradePolicy := compute.UpgradePolicy{
+		Mode:                     upgradeMode,
+		AutomaticOSUpgradePolicy: automaticOSUpgradePolicy,
+	}
+
+	virtualMachineProfile := compute.VirtualMachineScaleSetVMProfile{
+		OsProfile: &compute.VirtualMachineScaleSetOSProfile{
+			AdminUsername:      utils.String(d.Get("admin_username").(string)),
+			ComputerNamePrefix: utils.String(computerNamePrefix),
+			LinuxConfiguration: &compute.LinuxConfiguration{
+				DisablePasswordAuthentication: utils.Bool(disablePasswordAuthentication),
+				ProvisionVMAgent:              utils.Bool(d.Get("provision_vm_agent").(bool)),
+				SSH: &compute.SSHConfiguration{
+					PublicKeys: &sshKeys,
+				},
+			},
+			Secrets: secrets,
+		},
+		DiagnosticsProfile: bootDiagnostics,
+		NetworkProfile:     networkProfile,
+		StorageProfile: &compute.VirtualMachineScaleSetStorageProfile{
+			ImageReference: sourceImageReference,
+			OsDisk:         osDisk,
+			DataDisks:      dataDisks,
+		},
+	}
+
+	hasHealthExtension := false
+	if vmExtensionsRaw, ok := d.GetOk("extension"); ok {
+		virtualMachineProfile.ExtensionProfile, hasHealthExtension, err = expandVirtualMachineScaleSetExtensions(vmExtensionsRaw.(*pluginsdk.Set).List())
+		if err != nil {
+			return err
+		}
+	}
+
+	// otherwise the service return the error:
+	// Rolling Upgrade mode is not supported for this Virtual Machine Scale Set because a health probe or health extension was not provided.
+	if upgradeMode == compute.UpgradeModeRolling && (healthProbeId == "" && !hasHealthExtension) {
+		return fmt.Errorf("`health_probe_id` must be set or a health extension must be specified when `upgrade_mode` is set to %q", string(upgradeMode))
+	}
+
+	if adminPassword, ok := d.GetOk("admin_password"); ok {
+		virtualMachineProfile.OsProfile.AdminPassword = utils.String(adminPassword.(string))
+	}
+
+	if v, ok := d.GetOk("custom_data"); ok {
+		virtualMachineProfile.OsProfile.CustomData = utils.String(v.(string))
+	}
+
+	if encryptionAtHostEnabled, ok := d.GetOk("encryption_at_host_enabled"); ok {
+		virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{
+			EncryptionAtHost: utils.Bool(encryptionAtHostEnabled.(bool)),
+		}
+	}
+
+	// Azure API: "Authentication using either SSH or by user name and password must be enabled in Linux profile."
+	if disablePasswordAuthentication && virtualMachineProfile.OsProfile.AdminPassword == nil && len(sshKeys) == 0 {
+		return fmt.Errorf("at least one SSH key must be specified if `disable_password_authentication` is enabled")
+	}
+
+	if v, ok := d.GetOk("terminate_notification"); ok {
+		virtualMachineProfile.ScheduledEventsProfile = ExpandVirtualMachineScaleSetScheduledEventsProfile(v.([]interface{}))
+	}
+
+	scaleInPolicy := d.Get("scale_in_policy").(string)
+	automaticRepairsPolicyRaw := d.Get("automatic_instance_repair").([]interface{})
+	automaticRepairsPolicy := ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(automaticRepairsPolicyRaw)
+
+	props := compute.VirtualMachineScaleSet{
+		Location: utils.String(location),
+		Sku: &compute.Sku{
+			Name:     utils.String(d.Get("sku").(string)),
+			Capacity: utils.Int64(int64(d.Get("instances").(int))),
+
+			// doesn't appear this can be set to anything else, even Promo machines are Standard
+			Tier: utils.String("Standard"),
+		},
+		Plan: plan,
+		Tags: tags.Expand(t),
+		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+			AdditionalCapabilities:                 additionalCapabilities,
+			AutomaticRepairsPolicy:                 automaticRepairsPolicy,
+			DoNotRunExtensionsOnOverprovisionedVMs: utils.Bool(d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)),
+			Overprovision:                          utils.Bool(d.Get("overprovision").(bool)),
+			SinglePlacementGroup:                   utils.Bool(d.Get("single_placement_group").(bool)),
+			VirtualMachineProfile:                  &virtualMachineProfile,
+			UpgradePolicy:                          &upgradePolicy,
+			// OrchestrationMode needs to be hardcoded to Uniform, for the
+			// standard VMSS resource, since virtualMachineProfile is now supported
+			// in both VMSS and Orchestrated VMSS...
+			ScaleInPolicy: &compute.ScaleInPolicy{
+				Rules: &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(scaleInPolicy)},
+			},
+		},
+	}
+
+	if v, ok := d.GetOk("platform_fault_domain_count"); ok {
+		props.VirtualMachineScaleSetProperties.PlatformFaultDomainCount = utils.Int32(int32(v.(int)))
+	}
+
+	log.Printf("[DEBUG] Creating Linux %s", id)
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, props)
+	if err != nil {
+		return fmt.Errorf("creating Linux %s: %+v", id, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for Linux %s to be created..", id)
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation of Linux %s: %+v", id, err)
+	}
+	log.Printf("[DEBUG] %s was created", id)
+
+	d.SetId(id.ID())
+
+	return resourceLinuxVirtualMachineScaleSetRead(d, meta)
+}
+
+func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualMachineScaleSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	updateInstances := false
+
+	// retrieve
+	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	if existing.VirtualMachineScaleSetProperties == nil {
+		return fmt.Errorf("retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
+	}
+	if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile == nil {
+		return fmt.Errorf("retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): `properties.virtualMachineProfile` was nil", id.Name, id.ResourceGroup)
+	}
+	if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile == nil {
+		return fmt.Errorf("retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): `properties.virtualMachineProfile,storageProfile` was nil", id.Name, id.ResourceGroup)
+	}
+
+	updateProps := compute.VirtualMachineScaleSetUpdateProperties{
+		VirtualMachineProfile: &compute.VirtualMachineScaleSetUpdateVMProfile{
+			// if an image reference has been configured previously (it has to be), we would better to include that in this
+			// update request to avoid some circumstances that the API will complain ImageReference is null
+			// issue tracking: https://github.com/Azure/azure-rest-api-specs/issues/10322
+			StorageProfile: &compute.VirtualMachineScaleSetUpdateStorageProfile{
+				ImageReference: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.ImageReference,
+			},
+		},
+		// if an upgrade policy's been configured previously (which it will have) it must be threaded through
+		// this doesn't matter for Manual - but breaks when updating anything on a Automatic and Rolling Mode Scale Set
+		UpgradePolicy: existing.VirtualMachineScaleSetProperties.UpgradePolicy,
+	}
+	update := compute.VirtualMachineScaleSetUpdate{}
+
+	// first try and pull this from existing vm, which covers no changes being made to this block
+	automaticOSUpgradeIsEnabled := false
+	if policy := existing.VirtualMachineScaleSetProperties.UpgradePolicy; policy != nil {
+		if policy.AutomaticOSUpgradePolicy != nil && policy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade != nil {
+			automaticOSUpgradeIsEnabled = *policy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade
+		}
+	}
+
+	if d.HasChange("automatic_os_upgrade_policy") {
+		upgradePolicy := compute.UpgradePolicy{}
+		if existing.VirtualMachineScaleSetProperties.UpgradePolicy == nil {
+			upgradePolicy = compute.UpgradePolicy{
+				Mode: compute.UpgradeMode(d.Get("upgrade_mode").(string)),
+			}
+		} else {
+			upgradePolicy = *existing.VirtualMachineScaleSetProperties.UpgradePolicy
+			upgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
+		}
+
+		if d.HasChange("automatic_os_upgrade_policy") {
+			automaticRaw := d.Get("automatic_os_upgrade_policy").([]interface{})
+			upgradePolicy.AutomaticOSUpgradePolicy = ExpandVirtualMachineScaleSetAutomaticUpgradePolicy(automaticRaw)
+
+			if upgradePolicy.AutomaticOSUpgradePolicy != nil {
+				automaticOSUpgradeIsEnabled = *upgradePolicy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade
+			}
+		}
+
+		updateProps.UpgradePolicy = &upgradePolicy
+	}
+
+	if d.HasChange("single_placement_group") {
+		updateProps.SinglePlacementGroup = utils.Bool(d.Get("single_placement_group").(bool))
+	}
+
+	if d.HasChange("admin_ssh_key") || d.HasChange("custom_data") || d.HasChange("disable_password_authentication") || d.HasChange("provision_vm_agent") || d.HasChange("secret") {
+		osProfile := compute.VirtualMachineScaleSetUpdateOSProfile{}
+
+		if d.HasChange("admin_ssh_key") || d.HasChange("disable_password_authentication") || d.HasChange("provision_vm_agent") {
+			linuxConfig := compute.LinuxConfiguration{}
+
+			if d.HasChange("admin_ssh_key") {
+				sshKeysRaw := d.Get("admin_ssh_key").(*pluginsdk.Set).List()
+				sshKeys := ExpandSSHKeys(sshKeysRaw)
+				linuxConfig.SSH = &compute.SSHConfiguration{
+					PublicKeys: &sshKeys,
+				}
+			}
+
+			if d.HasChange("disable_password_authentication") {
+				linuxConfig.DisablePasswordAuthentication = utils.Bool(d.Get("disable_password_authentication").(bool))
+			}
+
+			if d.HasChange("provision_vm_agent") {
+				linuxConfig.ProvisionVMAgent = utils.Bool(d.Get("provision_vm_agent").(bool))
+			}
+
+			osProfile.LinuxConfiguration = &linuxConfig
+		}
+
+		if d.HasChange("custom_data") {
+			updateInstances = true
+
+			// customData can only be sent if it's a base64 encoded string,
+			// so it's not possible to remove this without tainting the resource
+			if v, ok := d.GetOk("custom_data"); ok {
+				osProfile.CustomData = utils.String(v.(string))
+			}
+		}
+
+		if d.HasChange("secret") {
+			secretsRaw := d.Get("secret").([]interface{})
+			osProfile.Secrets = expandLinuxSecrets(secretsRaw)
+		}
+
+		updateProps.VirtualMachineProfile.OsProfile = &osProfile
+	}
+
+	if d.HasChange("data_disk") || d.HasChange("os_disk") || d.HasChange("source_image_id") || d.HasChange("source_image_reference") {
+		updateInstances = true
+
+		if updateProps.VirtualMachineProfile.StorageProfile == nil {
+			updateProps.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetUpdateStorageProfile{}
+		}
+
+		if d.HasChange("data_disk") {
+			ultraSSDEnabled := d.Get("additional_capabilities.0.ultra_ssd_enabled").(bool)
+			dataDisks, err := ExpandVirtualMachineScaleSetDataDisk(d.Get("data_disk").([]interface{}), ultraSSDEnabled)
+			if err != nil {
+				return fmt.Errorf("expanding `data_disk`: %+v", err)
+			}
+			updateProps.VirtualMachineProfile.StorageProfile.DataDisks = dataDisks
+		}
+
+		if d.HasChange("os_disk") {
+			osDiskRaw := d.Get("os_disk").([]interface{})
+			updateProps.VirtualMachineProfile.StorageProfile.OsDisk = ExpandVirtualMachineScaleSetOSDiskUpdate(osDiskRaw)
+		}
+
+		if d.HasChange("source_image_id") || d.HasChange("source_image_reference") {
+			sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
+			sourceImageId := d.Get("source_image_id").(string)
+			sourceImageReference, err := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+			if err != nil {
+				return err
+			}
+
+			updateProps.VirtualMachineProfile.StorageProfile.DataDisks = existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.DataDisks
+			updateProps.VirtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
+			updateProps.VirtualMachineProfile.StorageProfile.OsDisk = &compute.VirtualMachineScaleSetUpdateOSDisk{
+				Caching:                 existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Caching,
+				WriteAcceleratorEnabled: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.WriteAcceleratorEnabled,
+				DiskSizeGB:              existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.DiskSizeGB,
+				Image:                   existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Image,
+				VhdContainers:           existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers,
+				ManagedDisk:             existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.ManagedDisk,
+			}
+		}
+	}
+
+	if d.HasChange("network_interface") {
+		networkInterfacesRaw := d.Get("network_interface").([]interface{})
+		networkInterfaces, err := ExpandVirtualMachineScaleSetNetworkInterfaceUpdate(networkInterfacesRaw)
+		if err != nil {
+			return fmt.Errorf("expanding `network_interface`: %+v", err)
+		}
+
+		updateProps.VirtualMachineProfile.NetworkProfile = &compute.VirtualMachineScaleSetUpdateNetworkProfile{
+			NetworkInterfaceConfigurations: networkInterfaces,
+		}
+
+		healthProbeId := d.Get("health_probe_id").(string)
+		if healthProbeId != "" {
+			updateProps.VirtualMachineProfile.NetworkProfile.HealthProbe = &compute.APIEntityReference{
+				ID: utils.String(healthProbeId),
+			}
+		}
+	}
+
+	if d.HasChange("boot_diagnostics") {
+		updateInstances = true
+
+		bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
+		updateProps.VirtualMachineProfile.DiagnosticsProfile = expandBootDiagnostics(bootDiagnosticsRaw)
+	}
+
+	if d.HasChange("do_not_run_extensions_on_overprovisioned_machines") {
+		v := d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)
+		updateProps.DoNotRunExtensionsOnOverprovisionedVMs = utils.Bool(v)
+	}
+
+	if d.HasChange("overprovision") {
+		v := d.Get("overprovision").(bool)
+		updateProps.Overprovision = utils.Bool(v)
+	}
+
+	if d.HasChange("scale_in_policy") {
+		scaleInPolicy := d.Get("scale_in_policy").(string)
+		updateProps.ScaleInPolicy = &compute.ScaleInPolicy{
+			Rules: &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(scaleInPolicy)},
+		}
+	}
+
+	if d.HasChange("terminate_notification") {
+		notificationRaw := d.Get("terminate_notification").([]interface{})
+		updateProps.VirtualMachineProfile.ScheduledEventsProfile = ExpandVirtualMachineScaleSetScheduledEventsProfile(notificationRaw)
+	}
+
+	if d.HasChange("encryption_at_host_enabled") {
+		updateProps.VirtualMachineProfile.SecurityProfile = &compute.SecurityProfile{
+			EncryptionAtHost: utils.Bool(d.Get("encryption_at_host_enabled").(bool)),
+		}
+	}
+
+	if d.HasChange("automatic_instance_repair") {
+		automaticRepairsPolicyRaw := d.Get("automatic_instance_repair").([]interface{})
+		updateProps.AutomaticRepairsPolicy = ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(automaticRepairsPolicyRaw)
+	}
+
+	if d.HasChange("plan") {
+		planRaw := d.Get("plan").([]interface{})
+		update.Plan = expandPlan(planRaw)
+	}
+
+	if d.HasChange("sku") || d.HasChange("instances") {
+		// in-case ignore_changes is being used, since both fields are required
+		// look up the current values and override them as needed
+		sku := existing.Sku
+
+		if d.HasChange("sku") {
+			updateInstances = true
+
+			sku.Name = utils.String(d.Get("sku").(string))
+		}
+
+		if d.HasChange("instances") {
+			sku.Capacity = utils.Int64(int64(d.Get("instances").(int)))
+		}
+
+		update.Sku = sku
+	}
+
+	if d.HasChanges("extension") {
+		updateInstances = true
+
+		extensionProfile, _, err := expandVirtualMachineScaleSetExtensions(d.Get("extension").(*pluginsdk.Set).List())
+		if err != nil {
+			return err
+		}
+		updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile
+	}
+
+	if d.HasChange("tags") {
+		update.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	update.VirtualMachineScaleSetUpdateProperties = &updateProps
+
+	metaData := virtualMachineScaleSetUpdateMetaData{
+		AutomaticOSUpgradeIsEnabled: automaticOSUpgradeIsEnabled,
+		UpdateInstances:             updateInstances,
+		Client:                      meta.(*clients.Client).Compute,
+		Existing:                    existing,
+		ID:                          id,
+		OSType:                      compute.Linux,
+	}
+
+	if err := metaData.performUpdate(ctx, update); err != nil {
+		return err
+	}
+
+	return resourceLinuxVirtualMachineScaleSetRead(d, meta)
+}
+
+func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualMachineScaleSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Linux Virtual Machine Scale Set %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("location", location.NormalizeNilable(resp.Location))
+
+	var skuName *string
+	var instances int
+	if resp.Sku != nil {
+		skuName = resp.Sku.Name
+		if resp.Sku.Capacity != nil {
+			instances = int(*resp.Sku.Capacity)
+		}
+	}
+	d.Set("instances", instances)
+	d.Set("sku", skuName)
+
+	if err := d.Set("plan", flattenPlan(resp.Plan)); err != nil {
+		return fmt.Errorf("setting `plan`: %+v", err)
+	}
+
+	if resp.VirtualMachineScaleSetProperties == nil {
+		return fmt.Errorf("retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
+	}
+	props := *resp.VirtualMachineScaleSetProperties
+
+	if err := d.Set("additional_capabilities", FlattenVirtualMachineScaleSetAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
+		return fmt.Errorf("setting `additional_capabilities`: %+v", props.AdditionalCapabilities)
+	}
+
+	if err := d.Set("automatic_instance_repair", FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(props.AutomaticRepairsPolicy)); err != nil {
+		return fmt.Errorf("setting `automatic_instance_repair`: %+v", err)
+	}
+
+	d.Set("do_not_run_extensions_on_overprovisioned_machines", props.DoNotRunExtensionsOnOverprovisionedVMs)
+	d.Set("overprovision", props.Overprovision)
+	d.Set("platform_fault_domain_count", props.PlatformFaultDomainCount)
+	d.Set("single_placement_group", props.SinglePlacementGroup)
+	d.Set("unique_id", props.UniqueID)
+
+	rule := string(compute.Default)
+	if props.ScaleInPolicy != nil {
+		if rules := props.ScaleInPolicy.Rules; rules != nil && len(*rules) > 0 {
+			rule = string((*rules)[0])
+		}
+	}
+	d.Set("scale_in_policy", rule)
+
+	if profile := props.VirtualMachineProfile; profile != nil {
+		if err := d.Set("boot_diagnostics", flattenBootDiagnostics(profile.DiagnosticsProfile)); err != nil {
+			return fmt.Errorf("setting `boot_diagnostics`: %+v", err)
+		}
+
+		// the service just return empty when this is not assigned when provisioned
+		// See discussion on https://github.com/Azure/azure-rest-api-specs/issues/10971
+
+		if storageProfile := profile.StorageProfile; storageProfile != nil {
+			if err := d.Set("os_disk", FlattenVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {
+				return fmt.Errorf("setting `os_disk`: %+v", err)
+			}
+
+			if err := d.Set("data_disk", FlattenVirtualMachineScaleSetDataDisk(storageProfile.DataDisks)); err != nil {
+				return fmt.Errorf("setting `data_disk`: %+v", err)
+			}
+
+			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference)); err != nil {
+				return fmt.Errorf("setting `source_image_reference`: %+v", err)
+			}
+
+			var storageImageId string
+			if storageProfile.ImageReference != nil && storageProfile.ImageReference.ID != nil {
+				storageImageId = *storageProfile.ImageReference.ID
+			}
+			d.Set("source_image_id", storageImageId)
+		}
+
+		if osProfile := profile.OsProfile; osProfile != nil {
+			// admin_password isn't returned, but it's a top level field so we can ignore it without consequence
+			d.Set("admin_username", osProfile.AdminUsername)
+			d.Set("computer_name_prefix", osProfile.ComputerNamePrefix)
+
+			if linux := osProfile.LinuxConfiguration; linux != nil {
+				d.Set("disable_password_authentication", linux.DisablePasswordAuthentication)
+				d.Set("provision_vm_agent", linux.ProvisionVMAgent)
+
+				flattenedSshKeys, err := FlattenSSHKeys(linux.SSH)
+				if err != nil {
+					return fmt.Errorf("flattening `admin_ssh_key`: %+v", err)
+				}
+				if err := d.Set("admin_ssh_key", pluginsdk.NewSet(SSHKeySchemaHash, *flattenedSshKeys)); err != nil {
+					return fmt.Errorf("setting `admin_ssh_key`: %+v", err)
+				}
+			}
+
+			if err := d.Set("secret", flattenLinuxSecrets(osProfile.Secrets)); err != nil {
+				return fmt.Errorf("setting `secret`: %+v", err)
+			}
+		}
+
+		if nwProfile := profile.NetworkProfile; nwProfile != nil {
+			flattenedNics := FlattenVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
+			if err := d.Set("network_interface", flattenedNics); err != nil {
+				return fmt.Errorf("setting `network_interface`: %+v", err)
+			}
+
+			healthProbeId := ""
+			if nwProfile.HealthProbe != nil && nwProfile.HealthProbe.ID != nil {
+				healthProbeId = *nwProfile.HealthProbe.ID
+			}
+			d.Set("health_probe_id", healthProbeId)
+		}
+
+		if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
+			if err := d.Set("terminate_notification", FlattenVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
+				return fmt.Errorf("setting `terminate_notification`: %+v", err)
+			}
+		}
+
+		extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d)
+		if err != nil {
+			return fmt.Errorf("failed flattening `extension`: %+v", err)
+		}
+		d.Set("extension", extensionProfile)
+
+		encryptionAtHostEnabled := false
+
+		d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
+	}
+
+	if policy := props.UpgradePolicy; policy != nil {
+		d.Set("upgrade_mode", string(policy.Mode))
+
+		flattenedAutomatic := FlattenVirtualMachineScaleSetAutomaticOSUpgradePolicy(policy.AutomaticOSUpgradePolicy)
+		if err := d.Set("automatic_os_upgrade_policy", flattenedAutomatic); err != nil {
+			return fmt.Errorf("setting `automatic_os_upgrade_policy`: %+v", err)
+		}
+	}
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func resourceLinuxVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualMachineScaleSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	// Upgrading to the 2021-07-01 exposed a new expand parameter to the GET method
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return nil
+		}
+
+		return fmt.Errorf("retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	// Sometimes VMSS's aren't fully deleted when the `Delete` call returns - as such we'll try to scale the cluster
+	// to 0 nodes first, then delete the cluster - which should ensure there's no Network Interfaces kicking around
+	// and work around this Azure API bug:
+	// Original Error: Code="InUseSubnetCannotBeDeleted" Message="Subnet internal is in use by
+	// /{nicResourceID}/|providers|Microsoft.Compute|virtualMachineScaleSets|acctestvmss-190923101253410278|virtualMachines|0|networkInterfaces|example/ipConfigurations/internal and cannot be deleted.
+	// In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet.
+	scaleToZeroOnDelete := meta.(*clients.Client).Features.VirtualMachineScaleSet.ScaleToZeroOnDelete
+	if scaleToZeroOnDelete && resp.Sku != nil {
+		resp.Sku.Capacity = utils.Int64(int64(0))
+
+		log.Printf("[DEBUG] Scaling instances to 0 prior to deletion - this helps avoids networking issues within Azure")
+		update := compute.VirtualMachineScaleSetUpdate{
+			Sku: resp.Sku,
+		}
+		future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
+		if err != nil {
+			return fmt.Errorf("updating number of instances in Linux Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for scaling of instances to 0 prior to deletion - this helps avoids networking issues within Azure")
+		err = future.WaitForCompletionRef(ctx, client.Client)
+		if err != nil {
+			return fmt.Errorf("waiting for number of instances in Linux Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", id.Name, id.ResourceGroup, err)
+		}
+		log.Printf("[DEBUG] Scaled instances to 0 prior to deletion - this helps avoids networking issues within Azure")
+	} else {
+		log.Printf("[DEBUG] Unable to scale instances to `0` since the `sku` block is nil - trying to delete anyway")
+	}
+
+	log.Printf("[DEBUG] Deleting Linux Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	// @ArcturusZhang (mimicking from linux_virtual_machine_pluginsdk.go): sending `nil` here omits this value from being sent
+	// which matches the previous behaviour - we're only splitting this out so it's clear why
+	// TODO: support force deletion once it's out of Preview, if applicable
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("deleting Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for deletion of Linux Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for deletion of Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	log.Printf("[DEBUG] Deleted Linux Virtual Machine Scale Set %q (Resource Group %q).", id.Name, id.ResourceGroup)
+
+	return nil
+}

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
@@ -55,32 +55,3 @@ resource "azurestack_subnet" "test" {
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
-
-func (LinuxVirtualMachineScaleSetResource) templateWithLocation(data acceptance.TestData, location string) string {
-	return fmt.Sprintf(`
-# note: whilst these aren't used in all tests, it saves us redefining these everywhere
-locals {
-  first_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
-  second_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/NDMj2wG6bSa6jbn6E3LYlUsYiWMp1CQ2sGAijPALW6OrSu30lz7nKpoh8Qdw7/A4nAJgweI5Oiiw5/BOaGENM70Go+VM8LQMSxJ4S7/8MIJEZQp5HcJZ7XDTcEwruknrd8mllEfGyFzPvJOx6QAQocFhXBW6+AlhM3gn/dvV5vdrO8ihjET2GoDUqXPYC57ZuY+/Fz6W3KV8V97BvNUhpY5yQrP5VpnyvvXNFQtzDfClTvZFPuoHQi3/KYPi6O0FSD74vo8JOBZZY09boInPejkm9fvHQqfh0bnN7B6XJoUwC1Qprrx+XIy7ust5AEn5XL7d4lOvcR14MxDDKEp you@me.com"
-}
-
-resource "azurestack_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurestack_virtual_network" "test" {
-  name                = "acctestnw-%d"
-  address_space       = ["10.0.0.0/16"]
-  location            = azurestack_resource_group.test.location
-  resource_group_name = azurestack_resource_group.test.name
-}
-
-resource "azurestack_subnet" "test" {
-  name                 = "internal"
-  resource_group_name  = azurestack_resource_group.test.name
-  virtual_network_name = azurestack_virtual_network.test.name
-  address_prefix       = "10.0.2.0/24"
-}
-`, data.RandomInteger, location, data.RandomInteger)
-}

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
@@ -1,0 +1,86 @@
+package compute_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/utils"
+)
+
+type LinuxVirtualMachineScaleSetResource struct{}
+
+func (r LinuxVirtualMachineScaleSetResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.VirtualMachineScaleSetID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Compute.VMScaleSetClient.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Compute Linux Virtual Machine Scale Set %q: %+v", id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (LinuxVirtualMachineScaleSetResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+# note: whilst these aren't used in all tests, it saves us redefining these everywhere
+locals {
+  first_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+  second_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/NDMj2wG6bSa6jbn6E3LYlUsYiWMp1CQ2sGAijPALW6OrSu30lz7nKpoh8Qdw7/A4nAJgweI5Oiiw5/BOaGENM70Go+VM8LQMSxJ4S7/8MIJEZQp5HcJZ7XDTcEwruknrd8mllEfGyFzPvJOx6QAQocFhXBW6+AlhM3gn/dvV5vdrO8ihjET2GoDUqXPYC57ZuY+/Fz6W3KV8V97BvNUhpY5yQrP5VpnyvvXNFQtzDfClTvZFPuoHQi3/KYPi6O0FSD74vo8JOBZZY09boInPejkm9fvHQqfh0bnN7B6XJoUwC1Qprrx+XIy7ust5AEn5XL7d4lOvcR14MxDDKEp you@me.com"
+}
+
+resource "azurestack_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurestack_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+}
+
+resource "azurestack_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurestack_resource_group.test.name
+  virtual_network_name = azurestack_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (LinuxVirtualMachineScaleSetResource) templateWithLocation(data acceptance.TestData, location string) string {
+	return fmt.Sprintf(`
+# note: whilst these aren't used in all tests, it saves us redefining these everywhere
+locals {
+  first_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+  second_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/NDMj2wG6bSa6jbn6E3LYlUsYiWMp1CQ2sGAijPALW6OrSu30lz7nKpoh8Qdw7/A4nAJgweI5Oiiw5/BOaGENM70Go+VM8LQMSxJ4S7/8MIJEZQp5HcJZ7XDTcEwruknrd8mllEfGyFzPvJOx6QAQocFhXBW6+AlhM3gn/dvV5vdrO8ihjET2GoDUqXPYC57ZuY+/Fz6W3KV8V97BvNUhpY5yQrP5VpnyvvXNFQtzDfClTvZFPuoHQi3/KYPi6O0FSD74vo8JOBZZY09boInPejkm9fvHQqfh0bnN7B6XJoUwC1Qprrx+XIy7ust5AEn5XL7d4lOvcR14MxDDKEp you@me.com"
+}
+
+resource "azurestack_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurestack_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+}
+
+resource "azurestack_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurestack_resource_group.test.name
+  virtual_network_name = azurestack_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+`, data.RandomInteger, location, data.RandomInteger)
+}

--- a/internal/services/compute/registration.go
+++ b/internal/services/compute/registration.go
@@ -42,6 +42,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurestack_virtual_machine_scale_set_extension":  virtualMachineScaleSetExtension(),
 		"azurestack_image":                                image(),
 		"azurestack_windows_virtual_machine":              windowsVirtualMachine(),
+		"azurestack_windows_virtual_machine_scale_set":    resourceWindowsVirtualMachineScaleSet(),
 	}
 
 	return resources

--- a/internal/services/compute/registration.go
+++ b/internal/services/compute/registration.go
@@ -33,6 +33,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	resources := map[string]*pluginsdk.Resource{
 		"azurestack_availability_set":                     availabilitySet(),
 		"azurestack_linux_virtual_machine":                linuxVirtualMachine(),
+		"azurestack_linux_virtual_machine_scale_set":      resourceLinuxVirtualMachineScaleSet(),
 		"azurestack_managed_disk":                         managedDisk(),
 		"azurestack_virtual_machine":                      virtualMachine(),
 		"azurestack_virtual_machine_data_disk_attachment": virtualMachineDataDiskAttachment(),

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1,0 +1,1092 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/az/resourceid"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/validate"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/utils"
+)
+
+func VirtualMachineScaleSetAdditionalCapabilitiesSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				// NOTE: requires registration to use:
+				// $ az feature show --namespace Microsoft.Compute --name UltraSSDWithVMSS
+				// $ az provider register -n Microsoft.Compute
+				"ultra_ssd_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+					ForceNew: true,
+				},
+			},
+		},
+	}
+}
+
+func ExpandVirtualMachineScaleSetAdditionalCapabilities(input []interface{}) *compute.AdditionalCapabilities {
+	capabilities := compute.AdditionalCapabilities{}
+
+	if len(input) > 0 {
+		raw := input[0].(map[string]interface{})
+
+		capabilities.UltraSSDEnabled = utils.Bool(raw["ultra_ssd_enabled"].(bool))
+	}
+
+	return &capabilities
+}
+
+func FlattenVirtualMachineScaleSetAdditionalCapabilities(input *compute.AdditionalCapabilities) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	ultraSsdEnabled := false
+
+	if input.UltraSSDEnabled != nil {
+		ultraSsdEnabled = *input.UltraSSDEnabled
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"ultra_ssd_enabled": ultraSsdEnabled,
+		},
+	}
+}
+
+func VirtualMachineScaleSetNetworkInterfaceSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Required: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"ip_configuration": virtualMachineScaleSetIPConfigurationSchema(),
+
+				"dns_servers": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+				// TODO 4.0: change this from enable_* to *_enabled
+				"enable_ip_forwarding": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"network_security_group_id": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: resourceid.ValidateResourceIDOrEmpty,
+				},
+				"primary": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		},
+	}
+}
+
+func virtualMachineScaleSetIPConfigurationSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Required: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"load_balancer_backend_address_pool_ids": {
+					Type:     pluginsdk.TypeSet,
+					Optional: true,
+					Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+					Set:      pluginsdk.HashString,
+				},
+
+				"load_balancer_inbound_nat_rules_ids": {
+					Type:     pluginsdk.TypeSet,
+					Optional: true,
+					Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+					Set:      pluginsdk.HashString,
+				},
+
+				"primary": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
+				"subnet_id": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: resourceid.ValidateResourceID,
+				},
+
+				"version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  string(compute.IPv4),
+					ValidateFunc: validation.StringInSlice([]string{
+						string(compute.IPv4),
+					}, false),
+				},
+			},
+		},
+	}
+}
+
+func ExpandVirtualMachineScaleSetNetworkInterface(input []interface{}) (*[]compute.VirtualMachineScaleSetNetworkConfiguration, error) {
+	output := make([]compute.VirtualMachineScaleSetNetworkConfiguration, 0)
+
+	for _, v := range input {
+		raw := v.(map[string]interface{})
+
+		dnsServers := utils.ExpandStringSlice(raw["dns_servers"].([]interface{}))
+
+		ipConfigurations := make([]compute.VirtualMachineScaleSetIPConfiguration, 0)
+		ipConfigurationsRaw := raw["ip_configuration"].([]interface{})
+		for _, configV := range ipConfigurationsRaw {
+			configRaw := configV.(map[string]interface{})
+			ipConfiguration := expandVirtualMachineScaleSetIPConfiguration(configRaw)
+
+			ipConfigurations = append(ipConfigurations, *ipConfiguration)
+		}
+
+		config := compute.VirtualMachineScaleSetNetworkConfiguration{
+			Name: utils.String(raw["name"].(string)),
+			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+				DNSSettings: &compute.VirtualMachineScaleSetNetworkConfigurationDNSSettings{
+					DNSServers: dnsServers,
+				},
+				EnableIPForwarding: utils.Bool(raw["enable_ip_forwarding"].(bool)),
+				IPConfigurations:   &ipConfigurations,
+				Primary:            utils.Bool(raw["primary"].(bool)),
+			},
+		}
+
+		if nsgId := raw["network_security_group_id"].(string); nsgId != "" {
+			config.VirtualMachineScaleSetNetworkConfigurationProperties.NetworkSecurityGroup = &compute.SubResource{
+				ID: utils.String(nsgId),
+			}
+		}
+
+		output = append(output, config)
+	}
+
+	return &output, nil
+}
+
+func expandVirtualMachineScaleSetIPConfiguration(raw map[string]interface{}) *compute.VirtualMachineScaleSetIPConfiguration {
+	primary := raw["primary"].(bool)
+	version := compute.IPVersion(raw["version"].(string))
+
+	loadBalancerBackendAddressPoolIdsRaw := raw["load_balancer_backend_address_pool_ids"].(*pluginsdk.Set).List()
+	loadBalancerBackendAddressPoolIds := expandIDsToSubResources(loadBalancerBackendAddressPoolIdsRaw)
+
+	loadBalancerInboundNatPoolIdsRaw := raw["load_balancer_inbound_nat_rules_ids"].(*pluginsdk.Set).List()
+	loadBalancerInboundNatPoolIds := expandIDsToSubResources(loadBalancerInboundNatPoolIdsRaw)
+
+	ipConfiguration := compute.VirtualMachineScaleSetIPConfiguration{
+		Name: utils.String(raw["name"].(string)),
+		VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+			Primary:                         utils.Bool(primary),
+			PrivateIPAddressVersion:         version,
+			LoadBalancerBackendAddressPools: loadBalancerBackendAddressPoolIds,
+			LoadBalancerInboundNatPools:     loadBalancerInboundNatPoolIds,
+		},
+	}
+
+	if subnetId := raw["subnet_id"].(string); subnetId != "" {
+		ipConfiguration.VirtualMachineScaleSetIPConfigurationProperties.Subnet = &compute.APIEntityReference{
+			ID: utils.String(subnetId),
+		}
+	}
+
+	return &ipConfiguration
+}
+
+func ExpandVirtualMachineScaleSetNetworkInterfaceUpdate(input []interface{}) (*[]compute.VirtualMachineScaleSetUpdateNetworkConfiguration, error) {
+	output := make([]compute.VirtualMachineScaleSetUpdateNetworkConfiguration, 0)
+
+	for _, v := range input {
+		raw := v.(map[string]interface{})
+
+		dnsServers := utils.ExpandStringSlice(raw["dns_servers"].([]interface{}))
+
+		ipConfigurations := make([]compute.VirtualMachineScaleSetUpdateIPConfiguration, 0)
+		ipConfigurationsRaw := raw["ip_configuration"].([]interface{})
+		for _, configV := range ipConfigurationsRaw {
+			configRaw := configV.(map[string]interface{})
+			ipConfiguration := expandVirtualMachineScaleSetIPConfigurationUpdate(configRaw)
+
+			ipConfigurations = append(ipConfigurations, *ipConfiguration)
+		}
+
+		config := compute.VirtualMachineScaleSetUpdateNetworkConfiguration{
+			Name: utils.String(raw["name"].(string)),
+			VirtualMachineScaleSetUpdateNetworkConfigurationProperties: &compute.VirtualMachineScaleSetUpdateNetworkConfigurationProperties{
+				DNSSettings: &compute.VirtualMachineScaleSetNetworkConfigurationDNSSettings{
+					DNSServers: dnsServers,
+				},
+				EnableIPForwarding: utils.Bool(raw["enable_ip_forwarding"].(bool)),
+				IPConfigurations:   &ipConfigurations,
+				Primary:            utils.Bool(raw["primary"].(bool)),
+			},
+		}
+
+		if nsgId := raw["network_security_group_id"].(string); nsgId != "" {
+			config.VirtualMachineScaleSetUpdateNetworkConfigurationProperties.NetworkSecurityGroup = &compute.SubResource{
+				ID: utils.String(nsgId),
+			}
+		}
+
+		output = append(output, config)
+	}
+
+	return &output, nil
+}
+
+func expandVirtualMachineScaleSetIPConfigurationUpdate(raw map[string]interface{}) *compute.VirtualMachineScaleSetUpdateIPConfiguration {
+	primary := raw["primary"].(bool)
+	version := compute.IPVersion(raw["version"].(string))
+
+	ipConfiguration := compute.VirtualMachineScaleSetUpdateIPConfiguration{
+		Name: utils.String(raw["name"].(string)),
+		VirtualMachineScaleSetUpdateIPConfigurationProperties: &compute.VirtualMachineScaleSetUpdateIPConfigurationProperties{
+			Primary:                 utils.Bool(primary),
+			PrivateIPAddressVersion: version,
+		},
+	}
+
+	if subnetId := raw["subnet_id"].(string); subnetId != "" {
+		ipConfiguration.VirtualMachineScaleSetUpdateIPConfigurationProperties.Subnet = &compute.APIEntityReference{
+			ID: utils.String(subnetId),
+		}
+	}
+
+	return &ipConfiguration
+}
+
+func FlattenVirtualMachineScaleSetNetworkInterface(input *[]compute.VirtualMachineScaleSetNetworkConfiguration) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	results := make([]interface{}, 0)
+	for _, v := range *input {
+		var name, networkSecurityGroupId string
+		if v.Name != nil {
+			name = *v.Name
+		}
+		if v.NetworkSecurityGroup != nil && v.NetworkSecurityGroup.ID != nil {
+			networkSecurityGroupId = *v.NetworkSecurityGroup.ID
+		}
+
+		var enableIPForwarding, primary bool
+		if v.EnableIPForwarding != nil {
+			enableIPForwarding = *v.EnableIPForwarding
+		}
+		if v.Primary != nil {
+			primary = *v.Primary
+		}
+
+		var dnsServers []interface{}
+		if settings := v.DNSSettings; settings != nil {
+			dnsServers = utils.FlattenStringSlice(v.DNSSettings.DNSServers)
+		}
+
+		var ipConfigurations []interface{}
+		if v.IPConfigurations != nil {
+			for _, configRaw := range *v.IPConfigurations {
+				config := flattenVirtualMachineScaleSetIPConfiguration(configRaw)
+				ipConfigurations = append(ipConfigurations, config)
+			}
+		}
+
+		results = append(results, map[string]interface{}{
+			"name":                      name,
+			"dns_servers":               dnsServers,
+			"enable_ip_forwarding":      enableIPForwarding,
+			"ip_configuration":          ipConfigurations,
+			"network_security_group_id": networkSecurityGroupId,
+			"primary":                   primary,
+		})
+	}
+
+	return results
+}
+
+func flattenVirtualMachineScaleSetIPConfiguration(input compute.VirtualMachineScaleSetIPConfiguration) map[string]interface{} {
+	var name, subnetId string
+	if input.Name != nil {
+		name = *input.Name
+	}
+	if input.Subnet != nil && input.Subnet.ID != nil {
+		subnetId = *input.Subnet.ID
+	}
+
+	var primary bool
+	if input.Primary != nil {
+		primary = *input.Primary
+	}
+
+	loadBalancerBackendAddressPoolIds := flattenSubResourcesToIDs(input.LoadBalancerBackendAddressPools)
+	loadBalancerInboundNatRuleIds := flattenSubResourcesToIDs(input.LoadBalancerInboundNatPools)
+
+	return map[string]interface{}{
+		"name":                                   name,
+		"primary":                                primary,
+		"subnet_id":                              subnetId,
+		"version":                                string(input.PrivateIPAddressVersion),
+		"load_balancer_backend_address_pool_ids": loadBalancerBackendAddressPoolIds,
+		"load_balancer_inbound_nat_rules_ids":    loadBalancerInboundNatRuleIds,
+	}
+}
+
+func VirtualMachineScaleSetDataDiskSchema() *pluginsdk.Schema {
+	out := &pluginsdk.Schema{
+		// TODO: does this want to be a Set?
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"caching": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(compute.CachingTypesNone),
+						string(compute.CachingTypesReadOnly),
+						string(compute.CachingTypesReadWrite),
+					}, false),
+				},
+
+				"create_option": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(compute.DiskCreateOptionTypesEmpty),
+						string(compute.DiskCreateOptionTypesFromImage),
+					}, false),
+					Default: string(compute.DiskCreateOptionTypesEmpty),
+				},
+
+				"disk_encryption_set_id": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					// whilst the API allows updating this value, it's never actually set at Azure's end
+					// presumably this'll take effect once key rotation is supported a few months post-GA?
+					// however for now let's make this ForceNew since it can't be (successfully) updated
+					ForceNew:     true,
+					ValidateFunc: validate.DiskEncryptionSetID,
+				},
+
+				"disk_size_gb": {
+					Type:         pluginsdk.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(1, 32767),
+				},
+
+				"lun": {
+					Type:         pluginsdk.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(0, 2000), // TODO: confirm upper bounds
+				},
+
+				"storage_account_type": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(compute.StorageAccountTypesPremiumLRS),
+						string(compute.StorageAccountTypesStandardLRS),
+					}, false),
+				},
+
+				"write_accelerator_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		},
+	}
+
+	return out
+}
+
+func ExpandVirtualMachineScaleSetDataDisk(input []interface{}, ultraSSDEnabled bool) (*[]compute.VirtualMachineScaleSetDataDisk, error) {
+	disks := make([]compute.VirtualMachineScaleSetDataDisk, 0)
+
+	for _, v := range input {
+		raw := v.(map[string]interface{})
+
+		disk := compute.VirtualMachineScaleSetDataDisk{
+			Caching:    compute.CachingTypes(raw["caching"].(string)),
+			DiskSizeGB: utils.Int32(int32(raw["disk_size_gb"].(int))),
+			Lun:        utils.Int32(int32(raw["lun"].(int))),
+			ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
+				StorageAccountType: compute.StorageAccountTypes(raw["storage_account_type"].(string)),
+			},
+			WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
+			CreateOption:            compute.DiskCreateOptionTypes(raw["create_option"].(string)),
+		}
+
+		if id := raw["disk_encryption_set_id"].(string); id != "" {
+			disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
+				ID: utils.String(id),
+			}
+		}
+
+		disks = append(disks, disk)
+	}
+
+	return &disks, nil
+}
+
+func FlattenVirtualMachineScaleSetDataDisk(input *[]compute.VirtualMachineScaleSetDataDisk) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, v := range *input {
+		diskSizeGb := 0
+		if v.DiskSizeGB != nil && *v.DiskSizeGB != 0 {
+			diskSizeGb = int(*v.DiskSizeGB)
+		}
+
+		lun := 0
+		if v.Lun != nil {
+			lun = int(*v.Lun)
+		}
+
+		storageAccountType := ""
+		diskEncryptionSetId := ""
+		if v.ManagedDisk != nil {
+			storageAccountType = string(v.ManagedDisk.StorageAccountType)
+			if v.ManagedDisk.DiskEncryptionSet != nil && v.ManagedDisk.DiskEncryptionSet.ID != nil {
+				diskEncryptionSetId = *v.ManagedDisk.DiskEncryptionSet.ID
+			}
+		}
+
+		writeAcceleratorEnabled := false
+		if v.WriteAcceleratorEnabled != nil {
+			writeAcceleratorEnabled = *v.WriteAcceleratorEnabled
+		}
+
+		dataDisk := map[string]interface{}{
+			"caching":                   string(v.Caching),
+			"create_option":             string(v.CreateOption),
+			"lun":                       lun,
+			"disk_encryption_set_id":    diskEncryptionSetId,
+			"disk_size_gb":              diskSizeGb,
+			"storage_account_type":      storageAccountType,
+			"write_accelerator_enabled": writeAcceleratorEnabled,
+		}
+
+		output = append(output, dataDisk)
+	}
+
+	return output
+}
+
+func VirtualMachineScaleSetOSDiskSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"caching": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(compute.CachingTypesNone),
+						string(compute.CachingTypesReadOnly),
+						string(compute.CachingTypesReadWrite),
+					}, false),
+				},
+				"storage_account_type": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+					// whilst this appears in the Update block the API returns this when changing:
+					// Changing property 'osDisk.managedDisk.storageAccountType' is not allowed
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						// note: OS Disks don't support Ultra SSDs
+						string(compute.StorageAccountTypesPremiumLRS),
+						string(compute.StorageAccountTypesStandardLRS),
+					}, false),
+				},
+
+				"diff_disk_settings": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"option": {
+								Type:     pluginsdk.TypeString,
+								Required: true,
+								ForceNew: true,
+								ValidateFunc: validation.StringInSlice([]string{
+									string(compute.Local),
+								}, false),
+							},
+						},
+					},
+				},
+
+				"disk_encryption_set_id": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					// whilst the API allows updating this value, it's never actually set at Azure's end
+					// presumably this'll take effect once key rotation is supported a few months post-GA?
+					// however for now let's make this ForceNew since it can't be (successfully) updated
+					ForceNew:     true,
+					ValidateFunc: validate.DiskEncryptionSetID,
+				},
+
+				"disk_size_gb": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 4095),
+				},
+
+				"write_accelerator_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		},
+	}
+}
+
+func ExpandVirtualMachineScaleSetOSDisk(input []interface{}, osType compute.OperatingSystemTypes) *compute.VirtualMachineScaleSetOSDisk {
+	raw := input[0].(map[string]interface{})
+	disk := compute.VirtualMachineScaleSetOSDisk{
+		Caching: compute.CachingTypes(raw["caching"].(string)),
+		ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
+			StorageAccountType: compute.StorageAccountTypes(raw["storage_account_type"].(string)),
+		},
+		WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
+
+		// these have to be hard-coded so there's no point exposing them
+		CreateOption: compute.DiskCreateOptionTypesFromImage,
+		OsType:       osType,
+	}
+
+	if diskEncryptionSetId := raw["disk_encryption_set_id"].(string); diskEncryptionSetId != "" {
+		disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
+			ID: utils.String(diskEncryptionSetId),
+		}
+	}
+
+	if osDiskSize := raw["disk_size_gb"].(int); osDiskSize > 0 {
+		disk.DiskSizeGB = utils.Int32(int32(osDiskSize))
+	}
+
+	if diffDiskSettingsRaw := raw["diff_disk_settings"].([]interface{}); len(diffDiskSettingsRaw) > 0 {
+		diffDiskRaw := diffDiskSettingsRaw[0].(map[string]interface{})
+		disk.DiffDiskSettings = &compute.DiffDiskSettings{
+			Option: compute.DiffDiskOptions(diffDiskRaw["option"].(string)),
+		}
+	}
+
+	return &disk
+}
+
+func ExpandVirtualMachineScaleSetOSDiskUpdate(input []interface{}) *compute.VirtualMachineScaleSetUpdateOSDisk {
+	raw := input[0].(map[string]interface{})
+	disk := compute.VirtualMachineScaleSetUpdateOSDisk{
+		Caching: compute.CachingTypes(raw["caching"].(string)),
+		ManagedDisk: &compute.VirtualMachineScaleSetManagedDiskParameters{
+			StorageAccountType: compute.StorageAccountTypes(raw["storage_account_type"].(string)),
+		},
+		WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
+	}
+
+	if diskEncryptionSetId := raw["disk_encryption_set_id"].(string); diskEncryptionSetId != "" {
+		disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
+			ID: utils.String(diskEncryptionSetId),
+		}
+	}
+
+	if osDiskSize := raw["disk_size_gb"].(int); osDiskSize > 0 {
+		disk.DiskSizeGB = utils.Int32(int32(osDiskSize))
+	}
+
+	return &disk
+}
+
+func FlattenVirtualMachineScaleSetOSDisk(input *compute.VirtualMachineScaleSetOSDisk) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	diffDiskSettings := make([]interface{}, 0)
+	if input.DiffDiskSettings != nil {
+		diffDiskSettings = append(diffDiskSettings, map[string]interface{}{
+			"option": string(input.DiffDiskSettings.Option),
+		})
+	}
+
+	diskSizeGb := 0
+	if input.DiskSizeGB != nil && *input.DiskSizeGB != 0 {
+		diskSizeGb = int(*input.DiskSizeGB)
+	}
+
+	storageAccountType := ""
+	diskEncryptionSetId := ""
+	if input.ManagedDisk != nil {
+		storageAccountType = string(input.ManagedDisk.StorageAccountType)
+		if input.ManagedDisk.DiskEncryptionSet != nil && input.ManagedDisk.DiskEncryptionSet.ID != nil {
+			diskEncryptionSetId = *input.ManagedDisk.DiskEncryptionSet.ID
+		}
+	}
+
+	writeAcceleratorEnabled := false
+	if input.WriteAcceleratorEnabled != nil {
+		writeAcceleratorEnabled = *input.WriteAcceleratorEnabled
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"caching":                   string(input.Caching),
+			"disk_size_gb":              diskSizeGb,
+			"diff_disk_settings":        diffDiskSettings,
+			"storage_account_type":      storageAccountType,
+			"write_accelerator_enabled": writeAcceleratorEnabled,
+			"disk_encryption_set_id":    diskEncryptionSetId,
+		},
+	}
+}
+
+func VirtualMachineScaleSetAutomatedOSUpgradePolicySchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				// TODO: should these be optional + defaulted?
+				"disable_automatic_rollback": {
+					Type:     pluginsdk.TypeBool,
+					Required: true,
+				},
+				// TODO 4.0: change this from enable_* to *_enabled
+				"enable_automatic_os_upgrade": {
+					Type:     pluginsdk.TypeBool,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func ExpandVirtualMachineScaleSetAutomaticUpgradePolicy(input []interface{}) *compute.AutomaticOSUpgradePolicy {
+	if len(input) == 0 {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	return &compute.AutomaticOSUpgradePolicy{
+		DisableAutomaticRollback: utils.Bool(raw["disable_automatic_rollback"].(bool)),
+		EnableAutomaticOSUpgrade: utils.Bool(raw["enable_automatic_os_upgrade"].(bool)),
+	}
+}
+
+func FlattenVirtualMachineScaleSetAutomaticOSUpgradePolicy(input *compute.AutomaticOSUpgradePolicy) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	disableAutomaticRollback := false
+	if input.DisableAutomaticRollback != nil {
+		disableAutomaticRollback = *input.DisableAutomaticRollback
+	}
+
+	enableAutomaticOSUpgrade := false
+	if input.EnableAutomaticOSUpgrade != nil {
+		enableAutomaticOSUpgrade = *input.EnableAutomaticOSUpgrade
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"disable_automatic_rollback":  disableAutomaticRollback,
+			"enable_automatic_os_upgrade": enableAutomaticOSUpgrade,
+		},
+	}
+}
+
+func VirtualMachineScaleSetTerminateNotificationSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"enabled": {
+					Type:     pluginsdk.TypeBool,
+					Required: true,
+				},
+				"timeout": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: utils.ISO8601Duration,
+					Default:      "PT5M",
+				},
+			},
+		},
+	}
+}
+
+func ExpandVirtualMachineScaleSetScheduledEventsProfile(input []interface{}) *compute.ScheduledEventsProfile {
+	if len(input) == 0 {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	enabled := raw["enabled"].(bool)
+	timeout := raw["timeout"].(string)
+
+	return &compute.ScheduledEventsProfile{
+		TerminateNotificationProfile: &compute.TerminateNotificationProfile{
+			Enable:           &enabled,
+			NotBeforeTimeout: &timeout,
+		},
+	}
+}
+
+func FlattenVirtualMachineScaleSetScheduledEventsProfile(input *compute.ScheduledEventsProfile) []interface{} {
+	// if enabled is set to false, there will be no ScheduledEventsProfile in response, to avoid plan non empty when
+	// a user explicitly set enabled to false, we need to assign a default block to this field
+
+	enabled := false
+	if input != nil && input.TerminateNotificationProfile != nil && input.TerminateNotificationProfile.Enable != nil {
+		enabled = *input.TerminateNotificationProfile.Enable
+	}
+
+	timeout := "PT5M"
+	if input != nil && input.TerminateNotificationProfile != nil && input.TerminateNotificationProfile.NotBeforeTimeout != nil {
+		timeout = *input.TerminateNotificationProfile.NotBeforeTimeout
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"enabled": enabled,
+			"timeout": timeout,
+		},
+	}
+}
+
+func VirtualMachineScaleSetAutomaticRepairsPolicySchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"enabled": {
+					Type:     pluginsdk.TypeBool,
+					Required: true,
+				},
+				"grace_period": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  "PT30M",
+					// this field actually has a range from 30m to 90m, is there a function that can do this validation?
+					ValidateFunc: utils.ISO8601Duration,
+				},
+			},
+		},
+	}
+}
+
+func ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(input []interface{}) *compute.AutomaticRepairsPolicy {
+	if len(input) == 0 {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	return &compute.AutomaticRepairsPolicy{
+		Enabled:     utils.Bool(raw["enabled"].(bool)),
+		GracePeriod: utils.String(raw["grace_period"].(string)),
+	}
+}
+
+func FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(input *compute.AutomaticRepairsPolicy) []interface{} {
+	// if enabled is set to false, there will be no AutomaticRepairsPolicy in response, to avoid plan non empty when
+	// a user explicitly set enabled to false, we need to assign a default block to this field
+
+	enabled := false
+	if input != nil && input.Enabled != nil {
+		enabled = *input.Enabled
+	}
+
+	gracePeriod := "PT30M"
+	if input != nil && input.GracePeriod != nil {
+		gracePeriod = *input.GracePeriod
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"enabled":      enabled,
+			"grace_period": gracePeriod,
+		},
+	}
+}
+
+func VirtualMachineScaleSetExtensionsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeSet,
+		Optional: true,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"publisher": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"type": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"type_handler_version": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"auto_upgrade_minor_version": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+
+				"automatic_upgrade_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+				},
+
+				"force_update_tag": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+
+				"protected_settings": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringIsJSON,
+				},
+
+				"provision_after_extensions": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+
+				"settings": {
+					Type:             pluginsdk.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+				},
+			},
+		},
+		Set: virtualMachineScaleSetExtensionHash,
+	}
+}
+
+func expandVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfile *compute.VirtualMachineScaleSetExtensionProfile, hasHealthExtension bool, err error) {
+	extensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+	if len(input) == 0 {
+		return extensionProfile, false, nil
+	}
+
+	extensions := make([]compute.VirtualMachineScaleSetExtension, 0)
+	for _, v := range input {
+		extensionRaw := v.(map[string]interface{})
+		extension := compute.VirtualMachineScaleSetExtension{
+			Name: utils.String(extensionRaw["name"].(string)),
+		}
+		extensionType := extensionRaw["type"].(string)
+
+		extensionProps := compute.VirtualMachineScaleSetExtensionProperties{
+			Publisher:                utils.String(extensionRaw["publisher"].(string)),
+			Type:                     &extensionType,
+			TypeHandlerVersion:       utils.String(extensionRaw["type_handler_version"].(string)),
+			AutoUpgradeMinorVersion:  utils.Bool(extensionRaw["auto_upgrade_minor_version"].(bool)),
+			EnableAutomaticUpgrade:   utils.Bool(extensionRaw["automatic_upgrade_enabled"].(bool)),
+			ProvisionAfterExtensions: utils.ExpandStringSlice(extensionRaw["provision_after_extensions"].([]interface{})),
+		}
+
+		if extensionType == "ApplicationHealthLinux" || extensionType == "ApplicationHealthWindows" {
+			hasHealthExtension = true
+		}
+
+		if forceUpdateTag := extensionRaw["force_update_tag"]; forceUpdateTag != nil {
+			extensionProps.ForceUpdateTag = utils.String(forceUpdateTag.(string))
+		}
+
+		if val, ok := extensionRaw["settings"]; ok && val.(string) != "" {
+			settings, err := pluginsdk.ExpandJsonFromString(val.(string))
+			if err != nil {
+				return nil, false, fmt.Errorf("failed to parse JSON from `settings`: %+v", err)
+			}
+			extensionProps.Settings = settings
+		}
+
+		if val, ok := extensionRaw["protected_settings"]; ok && val.(string) != "" {
+			protectedSettings, err := pluginsdk.ExpandJsonFromString(val.(string))
+			if err != nil {
+				return nil, false, fmt.Errorf("failed to parse JSON from `protected_settings`: %+v", err)
+			}
+			extensionProps.ProtectedSettings = protectedSettings
+		}
+
+		extension.VirtualMachineScaleSetExtensionProperties = &extensionProps
+		extensions = append(extensions, extension)
+	}
+	extensionProfile.Extensions = &extensions
+
+	return extensionProfile, hasHealthExtension, nil
+}
+
+func flattenVirtualMachineScaleSetExtensions(input *compute.VirtualMachineScaleSetExtensionProfile, d *pluginsdk.ResourceData) ([]map[string]interface{}, error) {
+	result := make([]map[string]interface{}, 0)
+	if input == nil || input.Extensions == nil {
+		return result, nil
+	}
+
+	// extensionsFromState holds the "extension" block, which is used to retrieve the "protected_settings" to fill it back the state,
+	// since it is not returned from the API.
+	extensionsFromState := map[string]map[string]interface{}{}
+	if extSet, ok := d.GetOk("extension"); ok && extSet != nil {
+		extensions := extSet.(*pluginsdk.Set).List()
+		for _, ext := range extensions {
+			if ext == nil {
+				continue
+			}
+			ext := ext.(map[string]interface{})
+			extensionsFromState[ext["name"].(string)] = ext
+		}
+	}
+
+	for _, v := range *input.Extensions {
+		name := ""
+		if v.Name != nil {
+			name = *v.Name
+		}
+
+		autoUpgradeMinorVersion := false
+		enableAutomaticUpgrade := false
+		forceUpdateTag := ""
+		provisionAfterExtension := make([]interface{}, 0)
+		protectedSettings := ""
+		extPublisher := ""
+		extSettings := ""
+		extType := ""
+		extTypeVersion := ""
+
+		if props := v.VirtualMachineScaleSetExtensionProperties; props != nil {
+			if props.Publisher != nil {
+				extPublisher = *props.Publisher
+			}
+
+			if props.Type != nil {
+				extType = *props.Type
+			}
+
+			if props.TypeHandlerVersion != nil {
+				extTypeVersion = *props.TypeHandlerVersion
+			}
+
+			if props.AutoUpgradeMinorVersion != nil {
+				autoUpgradeMinorVersion = *props.AutoUpgradeMinorVersion
+			}
+
+			if props.EnableAutomaticUpgrade != nil {
+				enableAutomaticUpgrade = *props.EnableAutomaticUpgrade
+			}
+
+			if props.ForceUpdateTag != nil {
+				forceUpdateTag = *props.ForceUpdateTag
+			}
+
+			if props.ProvisionAfterExtensions != nil {
+				provisionAfterExtension = utils.FlattenStringSlice(props.ProvisionAfterExtensions)
+			}
+
+			if props.Settings != nil {
+				extSettingsRaw, err := pluginsdk.FlattenJsonToString(props.Settings.(map[string]interface{}))
+				if err != nil {
+					return nil, err
+				}
+				extSettings = extSettingsRaw
+			}
+		}
+		// protected_settings isn't returned, so we attempt to get it from state otherwise set to empty string
+		if ext, ok := extensionsFromState[name]; ok {
+			if protectedSettingsFromState, ok := ext["protected_settings"]; ok {
+				if protectedSettingsFromState.(string) != "" && protectedSettingsFromState.(string) != "{}" {
+					protectedSettings = protectedSettingsFromState.(string)
+				}
+			}
+		}
+
+		result = append(result, map[string]interface{}{
+			"name":                       name,
+			"auto_upgrade_minor_version": autoUpgradeMinorVersion,
+			"automatic_upgrade_enabled":  enableAutomaticUpgrade,
+			"force_update_tag":           forceUpdateTag,
+			"provision_after_extensions": provisionAfterExtension,
+			"protected_settings":         protectedSettings,
+			"publisher":                  extPublisher,
+			"settings":                   extSettings,
+			"type":                       extType,
+			"type_handler_version":       extTypeVersion,
+		})
+	}
+	return result, nil
+}

--- a/internal/services/compute/virtual_machine_scale_set_import.go
+++ b/internal/services/compute/virtual_machine_scale_set_import.go
@@ -1,0 +1,79 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/pluginsdk"
+)
+
+func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceType string) pluginsdk.ImporterFunc {
+	return func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) (data []*pluginsdk.ResourceData, err error) {
+		id, err := parse.VirtualMachineScaleSetID(d.Id())
+		if err != nil {
+			return []*pluginsdk.ResourceData{}, err
+		}
+
+		client := meta.(*clients.Client).Compute.VMScaleSetClient
+		// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
+		vm, err := client.Get(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if vm.VirtualMachineScaleSetProperties == nil {
+			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
+		}
+
+		if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile == nil {
+			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving Virtual Machine Scale Set %q (Resource Group %q): `properties.virtualMachineProfile` was nil", id.Name, id.ResourceGroup)
+		}
+
+		if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.OsProfile == nil {
+			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving Virtual Machine Scale Set %q (Resource Group %q): `properties.virtualMachineProfile.osProfile` was nil", id.Name, id.ResourceGroup)
+		}
+
+		isCorrectOS := false
+		hasSshKeys := false
+		if profile := vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.OsProfile; profile != nil {
+			if profile.LinuxConfiguration != nil && osType == compute.Linux {
+				isCorrectOS = true
+
+				if profile.LinuxConfiguration.SSH != nil && profile.LinuxConfiguration.SSH.PublicKeys != nil {
+					hasSshKeys = len(*profile.LinuxConfiguration.SSH.PublicKeys) > 0
+				}
+			}
+
+			if profile.WindowsConfiguration != nil && osType == compute.Windows {
+				isCorrectOS = true
+			}
+		}
+
+		if !isCorrectOS {
+			return []*pluginsdk.ResourceData{}, fmt.Errorf("The %q resource only supports %s Virtual Machine Scale Sets", resourceType, string(osType))
+		}
+
+		if !hasSshKeys {
+			d.Set("admin_password", "ignored-as-imported")
+		}
+
+		var updatedExtensions []map[string]interface{}
+		if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile != nil {
+			if extensionsProfile := vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile; extensionsProfile != nil {
+				for _, v := range *extensionsProfile.Extensions {
+					v.ProtectedSettings = ""
+				}
+				updatedExtensions, err = flattenVirtualMachineScaleSetExtensions(extensionsProfile, d)
+				if err != nil {
+					return []*pluginsdk.ResourceData{}, fmt.Errorf("could not read VMSS extensions data for %q (resource group %q)", id.Name, id.ResourceGroup)
+				}
+			}
+		}
+		d.Set("extension", updatedExtensions)
+
+		return []*pluginsdk.ResourceData{d}, nil
+	}
+}

--- a/internal/services/compute/virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_resource.go
@@ -796,7 +796,7 @@ func virtualMachineScaleSetCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		return err
 	}
 
-	extensions, err := expandVirtualMachineScaleSetExtensions(d)
+	extensions, _, err := expandVirtualMachineScaleSetExtensions(d.Get("extension").(*pluginsdk.Set).List())
 	if err != nil {
 		return err
 	}
@@ -2128,54 +2128,6 @@ func expandVirtualMachineScaleSetOsProfileSecrets(d *pluginsdk.ResourceData) *[]
 	}
 
 	return &secrets
-}
-
-func expandVirtualMachineScaleSetExtensions(d *pluginsdk.ResourceData) (*compute.VirtualMachineScaleSetExtensionProfile, error) {
-	extensions := d.Get("extension").(*pluginsdk.Set).List()
-	resources := make([]compute.VirtualMachineScaleSetExtension, 0, len(extensions))
-	for _, e := range extensions {
-		config := e.(map[string]interface{})
-		name := config["name"].(string)
-		publisher := config["publisher"].(string)
-		t := config["type"].(string)
-		version := config["type_handler_version"].(string)
-
-		extension := compute.VirtualMachineScaleSetExtension{
-			Name: &name,
-			VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
-				Publisher:          &publisher,
-				Type:               &t,
-				TypeHandlerVersion: &version,
-			},
-		}
-
-		if u := config["auto_upgrade_minor_version"]; u != nil {
-			upgrade := u.(bool)
-			extension.VirtualMachineScaleSetExtensionProperties.AutoUpgradeMinorVersion = &upgrade
-		}
-
-		if s := config["settings"].(string); s != "" {
-			settings, err := pluginsdk.ExpandJsonFromString(s)
-			if err != nil {
-				return nil, fmt.Errorf("unable to parse settings: %+v", err)
-			}
-			extension.VirtualMachineScaleSetExtensionProperties.Settings = &settings
-		}
-
-		if s := config["protected_settings"].(string); s != "" {
-			protectedSettings, err := pluginsdk.ExpandJsonFromString(s)
-			if err != nil {
-				return nil, fmt.Errorf("unable to parse protected_settings: %+v", err)
-			}
-			extension.VirtualMachineScaleSetExtensionProperties.ProtectedSettings = &protectedSettings
-		}
-
-		resources = append(resources, extension)
-	}
-
-	return &compute.VirtualMachineScaleSetExtensionProfile{
-		Extensions: &resources,
-	}, nil
 }
 
 func expandVirtualMachineScaleSetPlan(d *pluginsdk.ResourceData) *compute.Plan {

--- a/internal/services/compute/virtual_machine_scale_set_update.go
+++ b/internal/services/compute/virtual_machine_scale_set_update.go
@@ -1,0 +1,200 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/client"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/utils"
+)
+
+type virtualMachineScaleSetUpdateMetaData struct {
+	// is "automaticOSUpgrade" enable in the upgradeProfile block
+	AutomaticOSUpgradeIsEnabled bool
+
+	// can we roll instances if we need too? this is a feature toggle
+	CanRollInstancesWhenRequired bool
+
+	// do we need to roll the instances in this scale set?
+	UpdateInstances bool
+
+	Client   *client.Client
+	Existing compute.VirtualMachineScaleSet
+	ID       *parse.VirtualMachineScaleSetId
+	OSType   compute.OperatingSystemTypes
+}
+
+func (metadata virtualMachineScaleSetUpdateMetaData) performUpdate(ctx context.Context, update compute.VirtualMachineScaleSetUpdate) error {
+	if metadata.AutomaticOSUpgradeIsEnabled {
+		// Virtual Machine Scale Sets with Automatic OS Upgrade enabled must have all VM instances upgraded to same
+		// Platform Image. Upgrade all VM instances to latest Virtual Machine Scale Set model while property
+		// 'upgradePolicy.automaticOSUpgradePolicy.enableAutomaticOSUpgrade' is false and then update property
+		// 'upgradePolicy.automaticOSUpgradePolicy.enableAutomaticOSUpgrade' to true
+
+		update.VirtualMachineScaleSetUpdateProperties.UpgradePolicy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade = utils.Bool(false)
+	}
+
+	if err := metadata.updateVmss(ctx, update); err != nil {
+		return err
+	}
+
+	// if we update the SKU, we also need to subsequently roll the instances using the `UpdateInstances` API
+	if metadata.UpdateInstances {
+		userWantsToRollInstances := metadata.CanRollInstancesWhenRequired
+		upgradeMode := metadata.Existing.VirtualMachineScaleSetProperties.UpgradePolicy.Mode
+
+		if userWantsToRollInstances {
+			// If the updated image version is not "latest" and upgrade mode is automatic then azure will roll the instances automatically.
+			// Calling upgradeInstancesForAutomaticUpgradePolicy() in this case will cause an error.
+			if upgradeMode == compute.UpgradeModeAutomatic && isUsingLatestImage(update) {
+				if err := metadata.upgradeInstancesForAutomaticUpgradePolicy(ctx); err != nil {
+					return err
+				}
+			}
+
+			if upgradeMode == compute.UpgradeModeManual {
+				if err := metadata.upgradeInstancesForManualUpgradePolicy(ctx); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if metadata.AutomaticOSUpgradeIsEnabled {
+		// Virtual Machine Scale Sets with Automatic OS Upgrade enabled must have all VM instances upgraded to same
+		// Platform Image. Upgrade all VM instances to latest Virtual Machine Scale Set model while property
+		// 'upgradePolicy.automaticOSUpgradePolicy.enableAutomaticOSUpgrade' is false and then update property
+		// 'upgradePolicy.automaticOSUpgradePolicy.enableAutomaticOSUpgrade' to true
+
+		// finally set this to true
+		update.VirtualMachineScaleSetUpdateProperties.UpgradePolicy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade = utils.Bool(true)
+
+		// then update the VM
+		if err := metadata.updateVmss(ctx, update); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (metadata virtualMachineScaleSetUpdateMetaData) updateVmss(ctx context.Context, update compute.VirtualMachineScaleSetUpdate) error {
+	client := metadata.Client.VMScaleSetClient
+	id := metadata.ID
+
+	log.Printf("[DEBUG] Updating %s Virtual Machine Scale Set %q (Resource Group %q)..", metadata.OSType, id.Name, id.ResourceGroup)
+	future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
+	if err != nil {
+		return fmt.Errorf("updating %s Virtual Machine Scale Set %q (Resource Group %q): %+v", metadata.OSType, id.Name, id.ResourceGroup, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for update of %s Virtual Machine Scale Set %q (Resource Group %q)..", metadata.OSType, id.Name, id.ResourceGroup)
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for update of %s Virtual Machine Scale Set %q (Resource Group %q): %+v", metadata.OSType, id.Name, id.ResourceGroup, err)
+	}
+	log.Printf("[DEBUG] Updated %s Virtual Machine Scale Set %q (Resource Group %q).", metadata.OSType, id.Name, id.ResourceGroup)
+
+	return nil
+}
+
+func (metadata virtualMachineScaleSetUpdateMetaData) upgradeInstancesForAutomaticUpgradePolicy(ctx context.Context) error {
+	client := metadata.Client.VMScaleSetClient
+	rollingUpgradesClient := metadata.Client.VMScaleSetRollingUpgradesClient
+	id := metadata.ID
+
+	log.Printf("[DEBUG] Updating instances for %s Virtual Machine Scale Set %q (Resource Group %q)..", metadata.OSType, id.Name, id.ResourceGroup)
+	future, err := rollingUpgradesClient.StartOSUpgrade(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("updating instances for %s Virtual Machine Scale Set %q (Resource Group %q): %+v", metadata.OSType, id.Name, id.ResourceGroup, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for update of instances for %s Virtual Machine Scale Set %q (Resource Group %q)..", metadata.OSType, id.Name, id.ResourceGroup)
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for update of instances for %s Virtual Machine Scale Set %q (Resource Group %q): %+v", metadata.OSType, id.Name, id.ResourceGroup, err)
+	}
+	log.Printf("[DEBUG] Updated instances for %s Virtual Machine Scale Set %q (Resource Group %q).", metadata.OSType, id.Name, id.ResourceGroup)
+
+	return nil
+}
+
+func (metadata virtualMachineScaleSetUpdateMetaData) upgradeInstancesForManualUpgradePolicy(ctx context.Context) error {
+	client := metadata.Client.VMScaleSetClient
+	id := metadata.ID
+
+	log.Printf("[DEBUG] Rolling the VM Instances for %s Virtual Machine Scale Set %q (Resource Group %q)..", metadata.OSType, id.Name, id.ResourceGroup)
+	instancesClient := metadata.Client.VMScaleSetVMsClient
+	instances, err := instancesClient.ListComplete(ctx, id.ResourceGroup, id.Name, "", "", "")
+	if err != nil {
+		return fmt.Errorf("listing VM Instances for %s Virtual Machine Scale Set %q (Resource Group %q): %+v", metadata.OSType, id.Name, id.ResourceGroup, err)
+	}
+
+	log.Printf("[DEBUG] Determining instances to roll..")
+	instanceIdsToRoll := make([]string, 0)
+	for instances.NotDone() {
+		instance := instances.Value()
+		props := instance.VirtualMachineScaleSetVMProperties
+		if props != nil && instance.InstanceID != nil {
+			latestModel := props.LatestModelApplied
+			if latestModel != nil || !*latestModel {
+				instanceIdsToRoll = append(instanceIdsToRoll, *instance.InstanceID)
+			}
+		}
+
+		if err := instances.NextWithContext(ctx); err != nil {
+			return fmt.Errorf("enumerating instances: %s", err)
+		}
+	}
+
+	// TODO: there's a performance enhancement to do batches here, but this is fine for a first pass
+	for _, instanceId := range instanceIdsToRoll {
+		instanceIds := []string{instanceId}
+
+		log.Printf("[DEBUG] Updating Instance %q to the Latest Configuration..", instanceId)
+		ids := compute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+			InstanceIds: &instanceIds,
+		}
+		future, err := client.UpdateInstances(ctx, id.ResourceGroup, id.Name, ids)
+		if err != nil {
+			return fmt.Errorf("updating Instance %q (%s VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, metadata.OSType, id.Name, id.ResourceGroup, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("waiting for update of Instance %q (%s VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, metadata.OSType, id.Name, id.ResourceGroup, err)
+		}
+		log.Printf("[DEBUG] Updated Instance %q to the Latest Configuration.", instanceId)
+
+		// TODO: does this want to be a separate, user-configurable toggle?
+		log.Printf("[DEBUG] Reimaging Instance %q..", instanceId)
+		reimageInput := &compute.VirtualMachineScaleSetReimageParameters{
+			InstanceIds: &instanceIds,
+		}
+		reimageFuture, err := client.Reimage(ctx, id.ResourceGroup, id.Name, reimageInput)
+		if err != nil {
+			return fmt.Errorf("reimaging Instance %q (%s VM Scale Set %q / Resource Group %q): %+v", instanceId, metadata.OSType, id.Name, id.ResourceGroup, err)
+		}
+
+		if err = reimageFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("waiting for reimage of Instance %q (%s VM Scale Set %q / Resource Group %q): %+v", instanceId, metadata.OSType, id.Name, id.ResourceGroup, err)
+		}
+		log.Printf("[DEBUG] Reimaged Instance %q..", instanceId)
+	}
+
+	log.Printf("[DEBUG] Rolled the VM Instances for %s Virtual Machine Scale Set %q (Resource Group %q).", metadata.OSType, id.Name, id.ResourceGroup)
+	return nil
+}
+
+func isUsingLatestImage(update compute.VirtualMachineScaleSetUpdate) bool {
+	if update.VirtualMachineProfile.StorageProfile == nil ||
+		update.VirtualMachineProfile.StorageProfile.ImageReference == nil ||
+		update.VirtualMachineProfile.StorageProfile.ImageReference.Version == nil {
+		return false
+	}
+	if strings.EqualFold(*update.VirtualMachineProfile.StorageProfile.ImageReference.Version, "latest") {
+		return true
+	}
+	return false
+}

--- a/internal/services/compute/windows_virtual_machine_scale_set_auth_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_auth_resource_test.go
@@ -1,0 +1,63 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+)
+
+func TestAccWindowsVirtualMachineScaleSet_authPassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authPassword(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r WindowsVirtualMachineScaleSetResource) authPassword(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}

--- a/internal/services/compute/windows_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_disk_data_resource_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
 )
 
-func TestAccLinuxVirtualMachineScaleSet_disksDataDiskBasic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+func TestAccWindowsVirtualMachineScaleSet_disksDataDiskBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -23,9 +23,9 @@ func TestAccLinuxVirtualMachineScaleSet_disksDataDiskBasic(t *testing.T) {
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_disksDataDiskCaching(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+func TestAccWindowsVirtualMachineScaleSet_disksDataDiskCaching(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -52,9 +52,9 @@ func TestAccLinuxVirtualMachineScaleSet_disksDataDiskCaching(t *testing.T) {
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_disksDataDiskResizing(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+func TestAccWindowsVirtualMachineScaleSet_disksDataDiskResizing(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -76,9 +76,9 @@ func TestAccLinuxVirtualMachineScaleSet_disksDataDiskResizing(t *testing.T) {
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_disksDataDiskMultiple(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+func TestAccWindowsVirtualMachineScaleSet_disksDataDiskMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -91,9 +91,9 @@ func TestAccLinuxVirtualMachineScaleSet_disksDataDiskMultiple(t *testing.T) {
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_disksDataDiskRemove(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+func TestAccWindowsVirtualMachineScaleSet_disksDataDiskRemove(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -113,9 +113,9 @@ func TestAccLinuxVirtualMachineScaleSet_disksDataDiskRemove(t *testing.T) {
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_disksDataDiskScaling(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+func TestAccWindowsVirtualMachineScaleSet_disksDataDiskScaling(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -153,9 +153,9 @@ func TestAccLinuxVirtualMachineScaleSet_disksDataDiskScaling(t *testing.T) {
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+func TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -168,9 +168,9 @@ func TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardL
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+func TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -183,9 +183,9 @@ func TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLR
 	})
 }
 
-func TestAccLinuxVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurestack_linux_virtual_machine_scale_set", "test")
-	r := LinuxVirtualMachineScaleSetResource{}
+func TestAccWindowsVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -198,12 +198,12 @@ func TestAccLinuxVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled(t *
 	})
 }
 
-func (r LinuxVirtualMachineScaleSetResource) disksDataDiskBasic(data acceptance.TestData) string {
+func (r WindowsVirtualMachineScaleSetResource) disksDataDiskBasic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
-resource "azurestack_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
   resource_group_name = azurestack_resource_group.test.name
   location            = azurestack_resource_group.test.location
   sku                 = "Standard_F2"
@@ -211,12 +211,10 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
 
-  disable_password_authentication = false
-
   source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
     version   = "latest"
   }
 
@@ -243,15 +241,15 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }
 
-func (r LinuxVirtualMachineScaleSetResource) disksDataDiskCaching(data acceptance.TestData, caching string) string {
+func (r WindowsVirtualMachineScaleSetResource) disksDataDiskCaching(data acceptance.TestData, caching string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "azurestack_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
   resource_group_name = azurestack_resource_group.test.name
   location            = azurestack_resource_group.test.location
   sku                 = "Standard_F2"
@@ -259,12 +257,10 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
 
-  disable_password_authentication = false
-
   source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
     version   = "latest"
   }
 
@@ -291,15 +287,15 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger, caching)
+`, r.template(data), caching)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) disksDataDiskResize(data acceptance.TestData, diskSizeGb int) string {
+func (r WindowsVirtualMachineScaleSetResource) disksDataDiskResize(data acceptance.TestData, diskSizeGb int) string {
 	return fmt.Sprintf(`
 %s
 
-resource "azurestack_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
   resource_group_name = azurestack_resource_group.test.name
   location            = azurestack_resource_group.test.location
   sku                 = "Standard_F2"
@@ -307,12 +303,10 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
 
-  disable_password_authentication = false
-
   source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
     version   = "latest"
   }
 
@@ -339,15 +333,15 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger, diskSizeGb)
+`, r.template(data), diskSizeGb)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) disksDataDiskMultiple(data acceptance.TestData) string {
+func (r WindowsVirtualMachineScaleSetResource) disksDataDiskMultiple(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
-resource "azurestack_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
   resource_group_name = azurestack_resource_group.test.name
   location            = azurestack_resource_group.test.location
   sku                 = "Standard_F2"
@@ -355,12 +349,10 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
 
-  disable_password_authentication = false
-
   source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
     version   = "latest"
   }
 
@@ -394,15 +386,15 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }
 
-func (r LinuxVirtualMachineScaleSetResource) disksDataDiskStorageAccountType(data acceptance.TestData, storageAccountType string) string {
+func (r WindowsVirtualMachineScaleSetResource) disksDataDiskStorageAccountType(data acceptance.TestData, storageAccountType string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "azurestack_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
   resource_group_name = azurestack_resource_group.test.name
   location            = azurestack_resource_group.test.location
   sku                 = "Standard_F2s_v2"
@@ -410,12 +402,10 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
 
-  disable_password_authentication = false
-
   source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
     version   = "latest"
   }
 
@@ -442,15 +432,15 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger, storageAccountType)
+`, r.template(data), storageAccountType)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) disksDataDiskWriteAcceleratorEnabled(data acceptance.TestData) string {
+func (r WindowsVirtualMachineScaleSetResource) disksDataDiskWriteAcceleratorEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
-resource "azurestack_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
   resource_group_name = azurestack_resource_group.test.name
   location            = azurestack_resource_group.test.location
   sku                 = "Standard_DS14_v2"
@@ -458,12 +448,10 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
 
-  disable_password_authentication = false
-
   source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
     version   = "latest"
   }
 
@@ -491,5 +479,5 @@ resource "azurestack_linux_virtual_machine_scale_set" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data))
 }

--- a/internal/services/compute/windows_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_disk_os_resource_test.go
@@ -1,0 +1,326 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+)
+
+func TestAccWindowsVirtualMachineScaleSet_disksOSDiskCaching(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskCaching(data, "None"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.disksOSDiskCaching(data, "ReadOnly"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.disksOSDiskCaching(data, "ReadWrite"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_disksOSDiskCustomSize(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// unset
+			Config: r.authPassword(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.disksOSDiskCustomSize(data, 128),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// resize a second time to confirm https://github.com/Azure/azure-rest-api-specs/issues/1906
+			Config: r.disksOSDiskCustomSize(data, 256),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_disksOSDiskEphemeral(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskEphemeral(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskStorageAccountType(data, "Standard_LRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskStorageAccountType(data, "Premium_LRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskWriteAcceleratorEnabled(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r WindowsVirtualMachineScaleSetResource) disksOSDiskCaching(data acceptance.TestData, caching string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "%s"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), caching)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) disksOSDiskCustomSize(data acceptance.TestData, diskSize int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+    disk_size_gb         = %d
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), diskSize)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) disksOSDiskEphemeral(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F8s_v2" # has to be this large for ephemeral disks on Windows
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadOnly"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) disksOSDiskStorageAccountType(data acceptance.TestData, storageAccountType string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2s_v2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = %q
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), storageAccountType)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) disksOSDiskWriteAcceleratorEnabled(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_DS14_v2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type      = "Premium_LRS"
+    caching                   = "None"
+    write_accelerator_enabled = %t
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), enabled)
+}

--- a/internal/services/compute/windows_virtual_machine_scale_set_extensions_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_extensions_test.go
@@ -1,0 +1,95 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+)
+
+func TestAccWindowsVirtualMachineScaleSet_extensionDoNotRunOnOverProvisionedMachines(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionDoNotRunOnOverProvisionedMachines(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_extensionsDoNotRunOnOverProvisionedMachinesUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.extensionDoNotRunOnOverProvisionedMachines(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.extensionDoNotRunOnOverProvisionedMachines(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.extensionDoNotRunOnOverProvisionedMachines(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r WindowsVirtualMachineScaleSetResource) extensionDoNotRunOnOverProvisionedMachines(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+  overprovision       = true
+
+  do_not_run_extensions_on_overprovisioned_machines = %t
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), enabled)
+}

--- a/internal/services/compute/windows_virtual_machine_scale_set_network_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_network_resource_test.go
@@ -1,0 +1,736 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance/check"
+)
+
+func TestAccWindowsVirtualMachineScaleSet_networkDNSServers(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkDNSServers(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.networkDNSServersUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_networkIPForwarding(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// enabled
+			Config: r.networkIPForwarding(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// disabled
+			Config: r.networkPrivate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// enabled
+			Config: r.networkIPForwarding(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_networkLoadBalancer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkLoadBalancer(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_networkMultipleIPConfigurations(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkMultipleIPConfigurations(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_networkMultipleNICs(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkMultipleNICs(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkMultipleNICsMultipleIPConfigurations(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkMultipleNICsWithDifferentDNSServers(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkNetworkSecurityGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// without
+			Config: r.networkPrivate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// add one
+			Config: r.networkNetworkSecurityGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			// change it
+			Config: r.networkNetworkSecurityGroupUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_networkPrivate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurestack_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.networkPrivate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkDNSServers(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name        = "example"
+    primary     = true
+    dns_servers = ["8.8.8.8"]
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkDNSServersUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name        = "example"
+    primary     = true
+    dns_servers = ["1.1.1.1", "8.8.8.8"]
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkIPForwarding(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name                 = "example"
+    primary              = true
+    enable_ip_forwarding = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkLoadBalancer(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_public_ip" "test" {
+  name                = "test-ip-%d"
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+  allocation_method   = "Static"
+}
+
+resource "azurestack_lb" "test" {
+  name                = "acctestlb-%d"
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+
+  frontend_ip_configuration {
+    name                 = "internal"
+    public_ip_address_id = azurestack_public_ip.test.id
+  }
+}
+
+resource "azurestack_lb_backend_address_pool" "test" {
+  name                = "test"
+  resource_group_name = azurestack_resource_group.test.name
+  loadbalancer_id     = azurestack_lb.test.id
+}
+
+resource "azurestack_lb_nat_pool" "test" {
+  name                           = "test"
+  resource_group_name            = azurestack_resource_group.test.name
+  loadbalancer_id                = azurestack_lb.test.id
+  frontend_ip_configuration_name = "internal"
+  protocol                       = "Tcp"
+  frontend_port_start            = 80
+  frontend_port_end              = 81
+  backend_port                   = 8080
+}
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name                                   = "internal"
+      primary                                = true
+      subnet_id                              = azurestack_subnet.test.id
+      load_balancer_backend_address_pool_ids = [azurestack_lb_backend_address_pool.test.id]
+      load_balancer_inbound_nat_rules_ids    = [azurestack_lb_nat_pool.test.id]
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkMultipleIPConfigurations(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "internal"
+    primary = true
+
+    ip_configuration {
+      name      = "primary"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+
+    ip_configuration {
+      name      = "secondary"
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkMultipleNICs(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "primary"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  network_interface {
+    name = "secondary"
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkMultipleNICsMultipleIPConfigurations(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "primary"
+    primary = true
+
+    ip_configuration {
+      name      = "first"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+
+    ip_configuration {
+      name      = "second"
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  network_interface {
+    name = "secondary"
+
+    ip_configuration {
+      name      = "third"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+
+    ip_configuration {
+      name      = "fourth"
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkMultipleNICsWithDifferentDNSServers(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name        = "primary"
+    primary     = true
+    dns_servers = ["8.8.8.8"]
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+
+  network_interface {
+    name        = "secondary"
+    dns_servers = ["1.1.1.1"]
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkNetworkSecurityGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = "${azurestack_resource_group.test.location}"
+  resource_group_name = "${azurestack_resource_group.test.name}"
+}
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name                      = "example"
+    primary                   = true
+    network_security_group_id = azurestack_network_security_group.test.id
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkNetworkSecurityGroupUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = "${azurestack_resource_group.test.location}"
+  resource_group_name = "${azurestack_resource_group.test.name}"
+}
+
+resource "azurestack_network_security_group" "other" {
+  name                = "acctestnsg2-%d"
+  location            = "${azurestack_resource_group.test.location}"
+  resource_group_name = "${azurestack_resource_group.test.name}"
+}
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name                      = "example"
+    primary                   = true
+    network_security_group_id = azurestack_network_security_group.other.id
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) networkPrivate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurestack_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurestack_resource_group.test.name
+  location            = azurestack_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2012-Datacenter-smalldisk"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.test.id
+    }
+  }
+}
+`, r.template(data))
+}

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -1,0 +1,990 @@
+package compute
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/az/resourceid"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/az/tags"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/parse"
+	computeValidate "github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/validate"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/base64"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/timeouts"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/utils"
+)
+
+func resourceWindowsVirtualMachineScaleSet() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceWindowsVirtualMachineScaleSetCreate,
+		Read:   resourceWindowsVirtualMachineScaleSetRead,
+		Update: resourceWindowsVirtualMachineScaleSetUpdate,
+		Delete: resourceWindowsVirtualMachineScaleSetDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
+			_, err := parse.VirtualMachineScaleSetID(id)
+			return err
+		}, importVirtualMachineScaleSet(compute.Windows, "azurestack_windows_virtual_machine_scale_set")),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
+		},
+
+		// TODO: exposing requireGuestProvisionSignal once it's available
+		// https://github.com/Azure/azure-rest-api-specs/pull/7246
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: computeValidate.VirtualMachineName,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"location": commonschema.Location(),
+
+			// Required
+			"admin_username": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"admin_password": {
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				Sensitive:        true,
+				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
+				ValidateFunc:     validation.StringIsNotEmpty,
+			},
+
+			"network_interface": VirtualMachineScaleSetNetworkInterfaceSchema(),
+
+			"os_disk": VirtualMachineScaleSetOSDiskSchema(),
+
+			"instances": {
+				Type:         pluginsdk.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+
+			"sku": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			// Optional
+			"additional_capabilities": VirtualMachineScaleSetAdditionalCapabilitiesSchema(),
+
+			"additional_unattend_content": additionalUnattendContentSchema(),
+
+			"automatic_os_upgrade_policy": VirtualMachineScaleSetAutomatedOSUpgradePolicySchema(),
+
+			"automatic_instance_repair": VirtualMachineScaleSetAutomaticRepairsPolicySchema(),
+
+			"boot_diagnostics": bootDiagnosticsSchema(),
+
+			"computer_name_prefix": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+
+				// Computed since we reuse the VM name if one's not specified
+				Computed: true,
+				ForceNew: true,
+
+				ValidateFunc: computeValidate.WindowsComputerNamePrefix,
+			},
+
+			"custom_data": base64.OptionalSchema(false),
+
+			"data_disk": VirtualMachineScaleSetDataDiskSchema(),
+
+			"do_not_run_extensions_on_overprovisioned_machines": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			// TODO 4.0: change this from enable_* to *_enabled
+			"enable_automatic_updates": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"encryption_at_host_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"extension": VirtualMachineScaleSetExtensionsSchema(),
+
+			// TODO: Uncomment extensions_time_budget when it's fixed
+			/*"extensions_time_budget": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      "PT1H30M",
+				ValidateFunc: utils.ISO8601DurationBetween("PT15M", "PT2H"),
+			},*/
+
+			"health_probe_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: resourceid.ValidateResourceID,
+			},
+
+			"license_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"None",
+					"Windows_Client",
+					"Windows_Server",
+				}, false),
+				DiffSuppressFunc: func(_, old, new string, _ *pluginsdk.ResourceData) bool {
+					if old == "None" && new == "" || old == "" && new == "None" {
+						return true
+					}
+
+					return false
+				},
+			},
+
+			"overprovision": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"plan": planSchema(),
+
+			"platform_fault_domain_count": {
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
+			"provision_vm_agent": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+
+			"secret": windowsSecretSchema(),
+
+			"single_placement_group": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"source_image_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: resourceid.ValidateResourceID,
+			},
+
+			"source_image_reference": sourceImageReferenceSchema(false),
+
+			"tags": tags.Schema(),
+
+			"timezone": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: computeValidate.VirtualMachineTimeZone(),
+			},
+
+			"upgrade_mode": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  string(compute.UpgradeModeManual),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.UpgradeModeAutomatic),
+					string(compute.UpgradeModeManual),
+					string(compute.UpgradeModeRolling),
+				}, false),
+			},
+
+			"winrm_listener": winRmListenerSchema(),
+
+			"scale_in_policy": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(compute.Default),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.Default),
+					string(compute.NewestVM),
+					string(compute.OldestVM),
+				}, false),
+			},
+
+			"terminate_notification": VirtualMachineScaleSetTerminateNotificationSchema(),
+
+			// Computed
+			"unique_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	exists, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(exists.Response) {
+			return fmt.Errorf("checking for existing Windows %s: %+v", id, err)
+		}
+	}
+
+	if !utils.ResponseWasNotFound(exists.Response) {
+		return tf.ImportAsExistsError("azurestack_windows_virtual_machine_scale_set", *exists.ID)
+	}
+
+	location := location.Normalize(d.Get("location").(string))
+	t := d.Get("tags").(map[string]interface{})
+
+	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
+	additionalCapabilities := ExpandVirtualMachineScaleSetAdditionalCapabilities(additionalCapabilitiesRaw)
+
+	additionalUnattendContentRaw := d.Get("additional_unattend_content").([]interface{})
+	additionalUnattendContent := expandAdditionalUnattendContent(additionalUnattendContentRaw)
+
+	bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
+	bootDiagnostics := expandBootDiagnostics(bootDiagnosticsRaw)
+
+	dataDisksRaw := d.Get("data_disk").([]interface{})
+	ultraSSDEnabled := d.Get("additional_capabilities.0.ultra_ssd_enabled").(bool)
+	dataDisks, err := ExpandVirtualMachineScaleSetDataDisk(dataDisksRaw, ultraSSDEnabled)
+	if err != nil {
+		return fmt.Errorf("expanding `data_disk`: %+v", err)
+	}
+
+	networkInterfacesRaw := d.Get("network_interface").([]interface{})
+	networkInterfaces, err := ExpandVirtualMachineScaleSetNetworkInterface(networkInterfacesRaw)
+	if err != nil {
+		return fmt.Errorf("expanding `network_interface`: %+v", err)
+	}
+
+	osDiskRaw := d.Get("os_disk").([]interface{})
+	osDisk := ExpandVirtualMachineScaleSetOSDisk(osDiskRaw, compute.Windows)
+
+	planRaw := d.Get("plan").([]interface{})
+	plan := expandPlan(planRaw)
+
+	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
+	sourceImageId := d.Get("source_image_id").(string)
+	sourceImageReference, err := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+	if err != nil {
+		return err
+	}
+
+	healthProbeId := d.Get("health_probe_id").(string)
+	upgradeMode := compute.UpgradeMode(d.Get("upgrade_mode").(string))
+	automaticOSUpgradePolicyRaw := d.Get("automatic_os_upgrade_policy").([]interface{})
+	automaticOSUpgradePolicy := ExpandVirtualMachineScaleSetAutomaticUpgradePolicy(automaticOSUpgradePolicyRaw)
+
+	if upgradeMode != compute.UpgradeModeAutomatic && len(automaticOSUpgradePolicyRaw) > 0 {
+		return fmt.Errorf("an `automatic_os_upgrade_policy` block cannot be specified when `upgrade_mode` is not set to `Automatic`")
+	}
+
+	winRmListenersRaw := d.Get("winrm_listener").(*pluginsdk.Set).List()
+	winRmListeners := expandWinRMListener(winRmListenersRaw)
+
+	secretsRaw := d.Get("secret").([]interface{})
+	secrets := expandWindowsSecrets(secretsRaw)
+
+	var computerNamePrefix string
+	if v, ok := d.GetOk("computer_name_prefix"); ok && len(v.(string)) > 0 {
+		computerNamePrefix = v.(string)
+	} else {
+		_, errs := computeValidate.WindowsComputerNamePrefix(d.Get("name"), "computer_name_prefix")
+		if len(errs) > 0 {
+			return fmt.Errorf("unable to assume default computer name prefix %s. Please adjust the %q, or specify an explicit %q", errs[0], "name", "computer_name_prefix")
+		}
+		computerNamePrefix = id.Name
+	}
+
+	networkProfile := &compute.VirtualMachineScaleSetNetworkProfile{
+		NetworkInterfaceConfigurations: networkInterfaces,
+	}
+	if healthProbeId != "" {
+		networkProfile.HealthProbe = &compute.APIEntityReference{
+			ID: utils.String(healthProbeId),
+		}
+	}
+
+	upgradePolicy := compute.UpgradePolicy{
+		Mode:                     upgradeMode,
+		AutomaticOSUpgradePolicy: automaticOSUpgradePolicy,
+	}
+
+	virtualMachineProfile := compute.VirtualMachineScaleSetVMProfile{
+		OsProfile: &compute.VirtualMachineScaleSetOSProfile{
+			AdminPassword:      utils.String(d.Get("admin_password").(string)),
+			AdminUsername:      utils.String(d.Get("admin_username").(string)),
+			ComputerNamePrefix: utils.String(computerNamePrefix),
+			WindowsConfiguration: &compute.WindowsConfiguration{
+				ProvisionVMAgent: utils.Bool(d.Get("provision_vm_agent").(bool)),
+				WinRM:            winRmListeners,
+			},
+			Secrets: secrets,
+		},
+		DiagnosticsProfile: bootDiagnostics,
+		NetworkProfile:     networkProfile,
+		StorageProfile: &compute.VirtualMachineScaleSetStorageProfile{
+			ImageReference: sourceImageReference,
+			OsDisk:         osDisk,
+			DataDisks:      dataDisks,
+		},
+	}
+
+	hasHealthExtension := false
+	if vmExtensionsRaw, ok := d.GetOk("extension"); ok {
+		virtualMachineProfile.ExtensionProfile, hasHealthExtension, err = expandVirtualMachineScaleSetExtensions(vmExtensionsRaw.(*pluginsdk.Set).List())
+		if err != nil {
+			return err
+		}
+	}
+
+	// otherwise the service return the error:
+	// Rolling Upgrade mode is not supported for this Virtual Machine Scale Set because a health probe or health extension was not provided.
+	if upgradeMode == compute.UpgradeModeRolling && (healthProbeId == "" && !hasHealthExtension) {
+		return fmt.Errorf("`health_probe_id` must be set or a health extension must be specified when `upgrade_mode` is set to %q", string(upgradeMode))
+	}
+
+	enableAutomaticUpdates := d.Get("enable_automatic_updates").(bool)
+	virtualMachineProfile.OsProfile.WindowsConfiguration.EnableAutomaticUpdates = utils.Bool(enableAutomaticUpdates)
+
+	if v, ok := d.GetOk("custom_data"); ok {
+		virtualMachineProfile.OsProfile.CustomData = utils.String(v.(string))
+	}
+
+	if encryptionAtHostEnabled, ok := d.GetOk("encryption_at_host_enabled"); ok {
+		if virtualMachineProfile.SecurityProfile == nil {
+			virtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+		}
+		virtualMachineProfile.SecurityProfile.EncryptionAtHost = utils.Bool(encryptionAtHostEnabled.(bool))
+	}
+
+	if len(additionalUnattendContentRaw) > 0 {
+		virtualMachineProfile.OsProfile.WindowsConfiguration.AdditionalUnattendContent = additionalUnattendContent
+	}
+
+	if v, ok := d.GetOk("license_type"); ok {
+		virtualMachineProfile.LicenseType = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("timezone"); ok {
+		virtualMachineProfile.OsProfile.WindowsConfiguration.TimeZone = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("terminate_notification"); ok {
+		virtualMachineProfile.ScheduledEventsProfile = ExpandVirtualMachineScaleSetScheduledEventsProfile(v.([]interface{}))
+	}
+
+	scaleInPolicy := d.Get("scale_in_policy").(string)
+	automaticRepairsPolicyRaw := d.Get("automatic_instance_repair").([]interface{})
+	automaticRepairsPolicy := ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(automaticRepairsPolicyRaw)
+
+	props := compute.VirtualMachineScaleSet{
+		Location: utils.String(location),
+		Sku: &compute.Sku{
+			Name:     utils.String(d.Get("sku").(string)),
+			Capacity: utils.Int64(int64(d.Get("instances").(int))),
+
+			// doesn't appear this can be set to anything else, even Promo machines are Standard
+			Tier: utils.String("Standard"),
+		},
+		Plan: plan,
+		Tags: tags.Expand(t),
+		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+			AdditionalCapabilities:                 additionalCapabilities,
+			AutomaticRepairsPolicy:                 automaticRepairsPolicy,
+			DoNotRunExtensionsOnOverprovisionedVMs: utils.Bool(d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)),
+			Overprovision:                          utils.Bool(d.Get("overprovision").(bool)),
+			SinglePlacementGroup:                   utils.Bool(d.Get("single_placement_group").(bool)),
+			VirtualMachineProfile:                  &virtualMachineProfile,
+			UpgradePolicy:                          &upgradePolicy,
+			ScaleInPolicy: &compute.ScaleInPolicy{
+				Rules: &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(scaleInPolicy)},
+			},
+		},
+	}
+
+	if v, ok := d.GetOk("platform_fault_domain_count"); ok {
+		props.VirtualMachineScaleSetProperties.PlatformFaultDomainCount = utils.Int32(int32(v.(int)))
+	}
+
+	log.Printf("[DEBUG] Creating Windows %s.", id)
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, props)
+	if err != nil {
+		return fmt.Errorf("creating Windows %s: %+v", id, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for Windows %s to be created.", id)
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation of Windows %s: %+v", id, err)
+	}
+	log.Printf("[DEBUG] Windows %s was created", id)
+
+	d.SetId(id.ID())
+
+	return resourceWindowsVirtualMachineScaleSetRead(d, meta)
+}
+
+func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualMachineScaleSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	updateInstances := false
+
+	// retrieve
+	// Upgrading to the 2021-07-01 exposed a new expand parameter in the GET method
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	if existing.VirtualMachineScaleSetProperties == nil {
+		return fmt.Errorf("retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
+	}
+	if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile == nil {
+		return fmt.Errorf("retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): `properties.virtualMachineProfile` was nil", id.Name, id.ResourceGroup)
+	}
+	if existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile == nil {
+		return fmt.Errorf("retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): `properties.virtualMachineProfile,storageProfile` was nil", id.Name, id.ResourceGroup)
+	}
+
+	updateProps := compute.VirtualMachineScaleSetUpdateProperties{
+		VirtualMachineProfile: &compute.VirtualMachineScaleSetUpdateVMProfile{
+			// if an image reference has been configured previously (it has to be), we would better to include that in this
+			// update request to avoid some circumstances that the API will complain ImageReference is null
+			// issue tracking: https://github.com/Azure/azure-rest-api-specs/issues/10322
+			StorageProfile: &compute.VirtualMachineScaleSetUpdateStorageProfile{
+				ImageReference: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.ImageReference,
+			},
+		},
+		// if an upgrade policy's been configured previously (which it will have) it must be threaded through
+		// this doesn't matter for Manual - but breaks when updating anything on a Automatic and Rolling Mode Scale Set
+		UpgradePolicy: existing.VirtualMachineScaleSetProperties.UpgradePolicy,
+	}
+	update := compute.VirtualMachineScaleSetUpdate{}
+
+	upgradeMode := compute.UpgradeMode(d.Get("upgrade_mode").(string))
+	// first try and pull this from existing vm, which covers no changes being made to this block
+	automaticOSUpgradeIsEnabled := false
+	if policy := existing.VirtualMachineScaleSetProperties.UpgradePolicy; policy != nil {
+		if policy.AutomaticOSUpgradePolicy != nil && policy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade != nil {
+			automaticOSUpgradeIsEnabled = *policy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade
+		}
+	}
+	if d.HasChange("automatic_os_upgrade_policy") {
+		upgradePolicy := compute.UpgradePolicy{}
+		if existing.VirtualMachineScaleSetProperties.UpgradePolicy == nil {
+			upgradePolicy = compute.UpgradePolicy{
+				Mode: compute.UpgradeMode(d.Get("upgrade_mode").(string)),
+			}
+		} else {
+			upgradePolicy = *existing.VirtualMachineScaleSetProperties.UpgradePolicy
+			upgradePolicy.Mode = compute.UpgradeMode(d.Get("upgrade_mode").(string))
+		}
+
+		if d.HasChange("automatic_os_upgrade_policy") {
+			automaticRaw := d.Get("automatic_os_upgrade_policy").([]interface{})
+			upgradePolicy.AutomaticOSUpgradePolicy = ExpandVirtualMachineScaleSetAutomaticUpgradePolicy(automaticRaw)
+
+			// however if this block has been changed then we need to pull it
+			// we can guarantee this always has a value since it'll have been expanded and thus is safe to de-ref
+			automaticOSUpgradeIsEnabled = *upgradePolicy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade
+		}
+		updateProps.UpgradePolicy = &upgradePolicy
+	}
+
+	if d.HasChange("single_placement_group") {
+		updateProps.SinglePlacementGroup = utils.Bool(d.Get("single_placement_group").(bool))
+	}
+
+	if d.HasChange("enable_automatic_updates") ||
+		d.HasChange("custom_data") ||
+		d.HasChange("provision_vm_agent") ||
+		d.HasChange("secret") ||
+		d.HasChange("timezone") {
+		osProfile := compute.VirtualMachineScaleSetUpdateOSProfile{}
+
+		if d.HasChange("enable_automatic_updates") || d.HasChange("provision_vm_agent") || d.HasChange("timezone") {
+			windowsConfig := compute.WindowsConfiguration{}
+
+			if d.HasChange("enable_automatic_updates") {
+				if upgradeMode == compute.UpgradeModeAutomatic {
+					return fmt.Errorf("`enable_automatic_updates` cannot be changed for when `upgrade_mode` is `Automatic`")
+				}
+
+				windowsConfig.EnableAutomaticUpdates = utils.Bool(d.Get("enable_automatic_updates").(bool))
+			}
+
+			if d.HasChange("provision_vm_agent") {
+				windowsConfig.ProvisionVMAgent = utils.Bool(d.Get("provision_vm_agent").(bool))
+			}
+
+			if d.HasChange("timezone") {
+				windowsConfig.TimeZone = utils.String(d.Get("timezone").(string))
+			}
+
+			osProfile.WindowsConfiguration = &windowsConfig
+		}
+
+		if d.HasChange("custom_data") {
+			updateInstances = true
+
+			// customData can only be sent if it's a base64 encoded string,
+			// so it's not possible to remove this without tainting the resource
+			if v, ok := d.GetOk("custom_data"); ok {
+				osProfile.CustomData = utils.String(v.(string))
+			}
+		}
+
+		if d.HasChange("secret") {
+			secretsRaw := d.Get("secret").([]interface{})
+			osProfile.Secrets = expandWindowsSecrets(secretsRaw)
+		}
+
+		updateProps.VirtualMachineProfile.OsProfile = &osProfile
+	}
+
+	if d.HasChange("data_disk") || d.HasChange("os_disk") || d.HasChange("source_image_id") || d.HasChange("source_image_reference") {
+		updateInstances = true
+
+		if updateProps.VirtualMachineProfile.StorageProfile == nil {
+			updateProps.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetUpdateStorageProfile{}
+		}
+
+		if d.HasChange("data_disk") {
+			ultraSSDEnabled := d.Get("additional_capabilities.0.ultra_ssd_enabled").(bool)
+			dataDisks, err := ExpandVirtualMachineScaleSetDataDisk(d.Get("data_disk").([]interface{}), ultraSSDEnabled)
+			if err != nil {
+				return fmt.Errorf("expanding `data_disk`: %+v", err)
+			}
+			updateProps.VirtualMachineProfile.StorageProfile.DataDisks = dataDisks
+		}
+
+		if d.HasChange("os_disk") {
+			osDiskRaw := d.Get("os_disk").([]interface{})
+			updateProps.VirtualMachineProfile.StorageProfile.OsDisk = ExpandVirtualMachineScaleSetOSDiskUpdate(osDiskRaw)
+		}
+
+		if d.HasChange("source_image_id") || d.HasChange("source_image_reference") {
+			sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
+			sourceImageId := d.Get("source_image_id").(string)
+			sourceImageReference, err := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+			if err != nil {
+				return err
+			}
+
+			// Must include all storage profile properties when updating disk image.  See: https://github.com/hashicorp/terraform-provider-azurestack/issues/8273
+			updateProps.VirtualMachineProfile.StorageProfile.DataDisks = existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.DataDisks
+			updateProps.VirtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
+			updateProps.VirtualMachineProfile.StorageProfile.OsDisk = &compute.VirtualMachineScaleSetUpdateOSDisk{
+				Caching:                 existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Caching,
+				WriteAcceleratorEnabled: existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.WriteAcceleratorEnabled,
+				DiskSizeGB:              existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.DiskSizeGB,
+				Image:                   existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.Image,
+				VhdContainers:           existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers,
+				ManagedDisk:             existing.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.ManagedDisk,
+			}
+		}
+	}
+
+	if d.HasChange("network_interface") {
+		networkInterfacesRaw := d.Get("network_interface").([]interface{})
+		networkInterfaces, err := ExpandVirtualMachineScaleSetNetworkInterfaceUpdate(networkInterfacesRaw)
+		if err != nil {
+			return fmt.Errorf("expanding `network_interface`: %+v", err)
+		}
+
+		updateProps.VirtualMachineProfile.NetworkProfile = &compute.VirtualMachineScaleSetUpdateNetworkProfile{
+			NetworkInterfaceConfigurations: networkInterfaces,
+		}
+
+		healthProbeId := d.Get("health_probe_id").(string)
+		if healthProbeId != "" {
+			updateProps.VirtualMachineProfile.NetworkProfile.HealthProbe = &compute.APIEntityReference{
+				ID: utils.String(healthProbeId),
+			}
+		}
+	}
+
+	if d.HasChange("boot_diagnostics") {
+		updateInstances = true
+
+		bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
+		updateProps.VirtualMachineProfile.DiagnosticsProfile = expandBootDiagnostics(bootDiagnosticsRaw)
+	}
+
+	if d.HasChange("do_not_run_extensions_on_overprovisioned_machines") {
+		v := d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)
+		updateProps.DoNotRunExtensionsOnOverprovisionedVMs = utils.Bool(v)
+	}
+
+	if d.HasChange("scale_in_policy") {
+		scaleInPolicy := d.Get("scale_in_policy").(string)
+		updateProps.ScaleInPolicy = &compute.ScaleInPolicy{
+			Rules: &[]compute.VirtualMachineScaleSetScaleInRules{compute.VirtualMachineScaleSetScaleInRules(scaleInPolicy)},
+		}
+	}
+
+	if d.HasChange("terminate_notification") {
+		notificationRaw := d.Get("terminate_notification").([]interface{})
+		updateProps.VirtualMachineProfile.ScheduledEventsProfile = ExpandVirtualMachineScaleSetScheduledEventsProfile(notificationRaw)
+	}
+
+	if d.HasChange("encryption_at_host_enabled") {
+		if updateProps.VirtualMachineProfile.SecurityProfile == nil {
+			updateProps.VirtualMachineProfile.SecurityProfile = &compute.SecurityProfile{}
+		}
+		updateProps.VirtualMachineProfile.SecurityProfile.EncryptionAtHost = utils.Bool(d.Get("encryption_at_host_enabled").(bool))
+	}
+
+	if d.HasChange("license_type") {
+		license := d.Get("license_type").(string)
+		if license == "" {
+			// Only for create no specification is possible in the API. API does not allow empty string in update.
+			// So removing attribute license_type from Terraform configuration if it was set to value other than 'None' would lead to an endless loop in apply.
+			// To allow updating in this case set value explicitly to 'None'.
+			license = "None"
+		}
+		updateProps.VirtualMachineProfile.LicenseType = &license
+	}
+
+	if d.HasChange("automatic_instance_repair") {
+		automaticRepairsPolicyRaw := d.Get("automatic_instance_repair").([]interface{})
+		automaticRepairsPolicy := ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(automaticRepairsPolicyRaw)
+		updateProps.AutomaticRepairsPolicy = automaticRepairsPolicy
+	}
+
+	if d.HasChange("plan") {
+		planRaw := d.Get("plan").([]interface{})
+		update.Plan = expandPlan(planRaw)
+	}
+
+	if d.HasChange("sku") || d.HasChange("instances") {
+		// in-case ignore_changes is being used, since both fields are required
+		// look up the current values and override them as needed
+		sku := existing.Sku
+
+		if d.HasChange("sku") {
+			updateInstances = true
+
+			sku.Name = utils.String(d.Get("sku").(string))
+		}
+
+		if d.HasChange("instances") {
+			sku.Capacity = utils.Int64(int64(d.Get("instances").(int)))
+		}
+
+		update.Sku = sku
+	}
+
+	if d.HasChanges("extension") {
+		updateInstances = true
+
+		extensionProfile, _, err := expandVirtualMachineScaleSetExtensions(d.Get("extension").(*pluginsdk.Set).List())
+		if err != nil {
+			return err
+		}
+		updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile
+	}
+
+	if d.HasChange("tags") {
+		update.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	update.VirtualMachineScaleSetUpdateProperties = &updateProps
+
+	metaData := virtualMachineScaleSetUpdateMetaData{
+		AutomaticOSUpgradeIsEnabled:  automaticOSUpgradeIsEnabled,
+		CanRollInstancesWhenRequired: meta.(*clients.Client).Features.VirtualMachineScaleSet.RollInstancesWhenRequired,
+		UpdateInstances:              updateInstances,
+		Client:                       meta.(*clients.Client).Compute,
+		Existing:                     existing,
+		ID:                           id,
+		OSType:                       compute.Windows,
+	}
+
+	if err := metaData.performUpdate(ctx, update); err != nil {
+		return err
+	}
+
+	return resourceWindowsVirtualMachineScaleSetRead(d, meta)
+}
+
+func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualMachineScaleSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Windows Virtual Machine Scale Set %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("location", location.NormalizeNilable(resp.Location))
+
+	var skuName *string
+	var instances int
+	if resp.Sku != nil {
+		skuName = resp.Sku.Name
+		if resp.Sku.Capacity != nil {
+			instances = int(*resp.Sku.Capacity)
+		}
+	}
+	d.Set("instances", instances)
+	d.Set("sku", skuName)
+
+	if err := d.Set("plan", flattenPlan(resp.Plan)); err != nil {
+		return fmt.Errorf("setting `plan`: %+v", err)
+	}
+
+	if resp.VirtualMachineScaleSetProperties == nil {
+		return fmt.Errorf("retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
+	}
+	props := *resp.VirtualMachineScaleSetProperties
+
+	if err := d.Set("additional_capabilities", FlattenVirtualMachineScaleSetAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
+		return fmt.Errorf("setting `additional_capabilities`: %+v", props.AdditionalCapabilities)
+	}
+
+	if err := d.Set("automatic_instance_repair", FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(props.AutomaticRepairsPolicy)); err != nil {
+		return fmt.Errorf("setting `automatic_instance_repair`: %+v", err)
+	}
+
+	d.Set("do_not_run_extensions_on_overprovisioned_machines", props.DoNotRunExtensionsOnOverprovisionedVMs)
+	d.Set("overprovision", props.Overprovision)
+	d.Set("platform_fault_domain_count", props.PlatformFaultDomainCount)
+	d.Set("single_placement_group", props.SinglePlacementGroup)
+	d.Set("unique_id", props.UniqueID)
+
+	var upgradeMode compute.UpgradeMode
+	if policy := props.UpgradePolicy; policy != nil {
+		upgradeMode = policy.Mode
+		d.Set("upgrade_mode", string(policy.Mode))
+
+		flattenedAutomatic := FlattenVirtualMachineScaleSetAutomaticOSUpgradePolicy(policy.AutomaticOSUpgradePolicy)
+		if err := d.Set("automatic_os_upgrade_policy", flattenedAutomatic); err != nil {
+			return fmt.Errorf("setting `automatic_os_upgrade_policy`: %+v", err)
+		}
+	}
+
+	rule := string(compute.Default)
+	if props.ScaleInPolicy != nil {
+		if rules := props.ScaleInPolicy.Rules; rules != nil && len(*rules) > 0 {
+			rule = string((*rules)[0])
+		}
+	}
+	d.Set("scale_in_policy", rule)
+
+	if profile := props.VirtualMachineProfile; profile != nil {
+		if err := d.Set("boot_diagnostics", flattenBootDiagnostics(profile.DiagnosticsProfile)); err != nil {
+			return fmt.Errorf("setting `boot_diagnostics`: %+v", err)
+		}
+
+		// defaulted since BillingProfile isn't returned if it's unset
+		d.Set("license_type", profile.LicenseType)
+
+		// the service just return empty when this is not assigned when provisioned
+		// See discussion on https://github.com/Azure/azure-rest-api-specs/issues/10971
+		if storageProfile := profile.StorageProfile; storageProfile != nil {
+			if err := d.Set("os_disk", FlattenVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {
+				return fmt.Errorf("setting `os_disk`: %+v", err)
+			}
+
+			if err := d.Set("data_disk", FlattenVirtualMachineScaleSetDataDisk(storageProfile.DataDisks)); err != nil {
+				return fmt.Errorf("setting `data_disk`: %+v", err)
+			}
+
+			if err := d.Set("source_image_reference", flattenSourceImageReference(storageProfile.ImageReference)); err != nil {
+				return fmt.Errorf("setting `source_image_reference`: %+v", err)
+			}
+
+			var storageImageId string
+			if storageProfile.ImageReference != nil && storageProfile.ImageReference.ID != nil {
+				storageImageId = *storageProfile.ImageReference.ID
+			}
+			d.Set("source_image_id", storageImageId)
+		}
+
+		if osProfile := profile.OsProfile; osProfile != nil {
+			// admin_password isn't returned, but it's a top level field so we can ignore it without consequence
+			d.Set("admin_username", osProfile.AdminUsername)
+			d.Set("computer_name_prefix", osProfile.ComputerNamePrefix)
+
+			if err := d.Set("secret", flattenWindowsSecrets(osProfile.Secrets)); err != nil {
+				return fmt.Errorf("setting `secret`: %+v", err)
+			}
+
+			if windows := osProfile.WindowsConfiguration; windows != nil {
+				if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContent(windows.AdditionalUnattendContent, d)); err != nil {
+					return fmt.Errorf("setting `additional_unattend_content`: %+v", err)
+				}
+
+				enableAutomaticUpdates := false
+				if windows.EnableAutomaticUpdates != nil {
+					enableAutomaticUpdates = *windows.EnableAutomaticUpdates
+				}
+
+				// the API requires this is set to 'true' on submission (since it's now required for Windows VMSS's with
+				// an Automatic Upgrade Mode configured) however it actually returns false from the API..
+				// after a bunch of testing the least bad option appears to be not to set this if it's an Automatic Upgrade Mode
+				if upgradeMode != compute.UpgradeModeAutomatic {
+					d.Set("enable_automatic_updates", enableAutomaticUpdates)
+				}
+
+				d.Set("provision_vm_agent", windows.ProvisionVMAgent)
+				d.Set("timezone", windows.TimeZone)
+
+				if err := d.Set("winrm_listener", flattenWinRMListener(windows.WinRM)); err != nil {
+					return fmt.Errorf("setting `winrm_listener`: %+v", err)
+				}
+			}
+		}
+
+		if nwProfile := profile.NetworkProfile; nwProfile != nil {
+			flattenedNics := FlattenVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
+			if err := d.Set("network_interface", flattenedNics); err != nil {
+				return fmt.Errorf("setting `network_interface`: %+v", err)
+			}
+
+			healthProbeId := ""
+			if nwProfile.HealthProbe != nil && nwProfile.HealthProbe.ID != nil {
+				healthProbeId = *nwProfile.HealthProbe.ID
+			}
+			d.Set("health_probe_id", healthProbeId)
+		}
+
+		if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
+			if err := d.Set("terminate_notification", FlattenVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
+				return fmt.Errorf("setting `terminate_notification`: %+v", err)
+			}
+		}
+
+		extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d)
+		if err != nil {
+			return fmt.Errorf("failed flattening `extension`: %+v", err)
+		}
+		d.Set("extension", extensionProfile)
+
+		encryptionAtHostEnabled := false
+
+		d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
+	}
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func resourceWindowsVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.VirtualMachineScaleSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return nil
+		}
+
+		return fmt.Errorf("retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	// Sometimes VMSS's aren't fully deleted when the `Delete` call returns - as such we'll try to scale the cluster
+	// to 0 nodes first, then delete the cluster - which should ensure there's no Network Interfaces kicking around
+	// and work around this Azure API bug:
+	// Original Error: Code="InUseSubnetCannotBeDeleted" Message="Subnet internal is in use by
+	// /{nicResourceID}/|providers|Microsoft.Compute|virtualMachineScaleSets|acctestvmss-190923101253410278|virtualMachines|0|networkInterfaces|example/ipConfigurations/internal and cannot be deleted.
+	// In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet.
+	scaleToZeroOnDelete := meta.(*clients.Client).Features.VirtualMachineScaleSet.ScaleToZeroOnDelete
+	if scaleToZeroOnDelete && resp.Sku != nil {
+		resp.Sku.Capacity = utils.Int64(int64(0))
+
+		log.Printf("[DEBUG] Scaling instances to 0 prior to deletion - this helps avoids networking issues within Azure")
+		update := compute.VirtualMachineScaleSetUpdate{
+			Sku: resp.Sku,
+		}
+		future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
+		if err != nil {
+			return fmt.Errorf("updating number of instances in Windows Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for scaling of instances to 0 prior to deletion - this helps avoids networking issues within Azure")
+		err = future.WaitForCompletionRef(ctx, client.Client)
+		if err != nil {
+			return fmt.Errorf("waiting for number of instances in Windows Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", id.Name, id.ResourceGroup, err)
+		}
+		log.Printf("[DEBUG] Scaled instances to 0 prior to deletion - this helps avoids networking issues within Azure")
+	} else {
+		log.Printf("[DEBUG] Unable to scale instances to `0` since the `sku` block is nil - trying to delete anyway")
+	}
+
+	log.Printf("[DEBUG] Deleting Windows Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	// @ArcturusZhang (mimicking from windows_virtual_machine_pluginsdk.go): sending `nil` here omits this value from being sent
+	// which matches the previous behaviour - we're only splitting this out so it's clear why
+	// TODO: support force deletion once it's out of Preview, if applicable
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("deleting Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for deletion of Windows Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for deletion of Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	log.Printf("[DEBUG] Deleted Windows Virtual Machine Scale Set %q (Resource Group %q).", id.Name, id.ResourceGroup)
+
+	return nil
+}

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_test.go
@@ -1,0 +1,60 @@
+package compute_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/services/compute/parse"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/acceptance"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurestack/internal/utils"
+)
+
+type WindowsVirtualMachineScaleSetResource struct{}
+
+func (r WindowsVirtualMachineScaleSetResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.VirtualMachineScaleSetID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Compute.VMScaleSetClient.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Compute Windows Virtual Machine Scale Set %q", id)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (WindowsVirtualMachineScaleSetResource) vmName(data acceptance.TestData) string {
+	// windows VM names can be up to 15 chars, however the prefix can only be 9 chars
+	return fmt.Sprintf("acctvm%s", fmt.Sprintf("%d", data.RandomInteger)[0:2])
+}
+
+func (r WindowsVirtualMachineScaleSetResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+locals {
+  vm_name = "%s"
+}
+
+resource "azurestack_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurestack_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurestack_resource_group.test.location
+  resource_group_name = azurestack_resource_group.test.name
+}
+
+resource "azurestack_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurestack_resource_group.test.name
+  virtual_network_name = azurestack_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+`, r.vmName(data), data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -1,0 +1,441 @@
+---
+subcategory: "Compute"
+layout: "azurestack"
+page_title: "Azure Resource Manager: azurestack_linux_virtual_machine_scale_set"
+description: |-
+  Manages a Linux Virtual Machine Scale Set.
+---
+
+# azurestack_linux_virtual_machine_scale_set
+
+Manages a Linux Virtual Machine Scale Set.
+
+## Disclaimers
+
+~> **NOTE:** As of the **v2.86.0** (November 19, 2021) release of the provider this resource will only create Virtual Machine Scale Sets with the **Uniform** Orchestration Mode.
+
+~> **NOTE:** All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+-> **NOTE:** Terraform will automatically update & reimage the nodes in the Scale Set (if Required) during an Update - this behaviour can be configured [using the `features` setting within the Provider block](https://registry.terraform.io/providers/hashicorp/azurestack/latest/docs#features).
+
+## Example Usage
+
+This example provisions a basic Linux Virtual Machine Scale Set on an internal network. Additional examples of how to use the `azurestack_linux_virtual_machine_scale_set` resource can be found [in the ./examples/vm-scale-set/linux` directory within the Github Repository](https://github.com/hashicorp/terraform-provider-azurestack/tree/main/examples/vm-scale-set/linux).
+
+```hcl
+provider "azurestack" {
+  features {}
+}
+
+resource "azurestack_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurestack_virtual_network" "example" {
+  name                = "example-network"
+  resource_group_name = azurestack_resource_group.example.name
+  location            = azurestack_resource_group.example.location
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurestack_subnet" "internal" {
+  name                 = "internal"
+  resource_group_name  = azurestack_resource_group.example.name
+  virtual_network_name = azurestack_virtual_network.example.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurestack_linux_virtual_machine_scale_set" "example" {
+  name                = "example-vmss"
+  resource_group_name = azurestack_resource_group.example.name
+  location            = azurestack_resource_group.example.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = file("~/.ssh/id_rsa.pub")
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurestack_subnet.internal.id
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Linux Virtual Machine Scale Set. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure location where the Linux Virtual Machine Scale Set should exist. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group in which the Linux Virtual Machine Scale Set should be exist. Changing this forces a new resource to be created.
+
+* `admin_username` - (Required) The username of the local administrator on each Virtual Machine Scale Set instance. Changing this forces a new resource to be created.
+
+* `instances` - (Required) The number of Virtual Machines in the Scale Set.
+
+-> **NOTE:** If you're using AutoScaling, you may wish to use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/configuration/resources.html#ignore_changes) to ignore changes to this field.
+
+* `sku` - (Required) The Virtual Machine SKU for the Scale Set, such as `Standard_F2`.
+
+* `network_interface` - (Required) One or more `network_interface` blocks as defined below.
+
+* `os_disk` - (Required) An `os_disk` block as defined below.
+
+---
+
+* `additional_capabilities` - (Optional) A `additional_capabilities` block as defined below.
+
+* `admin_password` - (Optional) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
+
+-> **NOTE:** When an `admin_password` is specified `disable_password_authentication` must be set to `false`.
+
+~> **NOTE:** One of either `admin_password` or `admin_ssh_key` must be specified.
+
+* `admin_ssh_key` - (Optional) One or more `admin_ssh_key` blocks as defined below.
+
+~> **NOTE:** One of either `admin_password` or `admin_ssh_key` must be specified.
+
+* `automatic_os_upgrade_policy` - (Optional) A `automatic_os_upgrade_policy` block as defined below. This can only be specified when `upgrade_mode` is set to `Automatic`.
+
+* `automatic_instance_repair` - (Optional) A `automatic_instance_repair` block as defined below. To enable the automatic instance repair, this Virtual Machine Scale Set must have a valid `health_probe_id` or an [Application Health Extension](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension).
+
+~> **NOTE:** For more information about Automatic Instance Repair, please refer to [this doc](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-instance-repairs).
+
+* `boot_diagnostics` - (Optional) A `boot_diagnostics` block as defined below.
+
+* `computer_name_prefix` - (Optional) The prefix which should be used for the name of the Virtual Machines in this Scale Set. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name_prefix`, then you must specify `computer_name_prefix`.
+
+* `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine Scale Set.
+
+-> **NOTE:** When Custom Data has been configured, it's not possible to remove it without tainting the Virtual Machine Scale Set, due to a limitation of the Azure API.
+
+* `data_disk` - (Optional) One or more `data_disk` blocks as defined below.
+
+* `disable_password_authentication` - Should Password Authentication be disabled on this Virtual Machine Scale Set? Defaults to `true`.
+
+-> In general we'd recommend using SSH Keys for authentication rather than Passwords - but there's tradeoff's to each - please [see this thread for more information](https://security.stackexchange.com/questions/69407/why-is-using-an-ssh-key-more-secure-than-using-passwords).
+
+-> **NOTE:** When an `admin_password` is specified `disable_password_authentication` must be set to `false`.
+
+* `do_not_run_extensions_on_overprovisioned_machines` - (Optional) Should Virtual Machine Extensions be run on Overprovisioned Virtual Machines in the Scale Set? Defaults to `false`.
+
+* `encryption_at_host_enabled` - (Optional) Should all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host?
+
+* `extension` - (Optional) One or more `extension` blocks as defined below
+
+* `extensions_time_budget` - (Optional) Specifies the duration allocated for all extensions to start. The time duration should be between `15` minutes and `120` minutes (inclusive) and should be specified in ISO 8601 format. Defaults to `90` minutes (`PT1H30M`).
+
+-> **NOTE:** This can only be configured when `priority` is set to `Spot`.
+
+* `health_probe_id` - (Optional) The ID of a Load Balancer Probe which should be used to determine the health of an instance. This is Required and can only be specified when `upgrade_mode` is set to `Automatic` or `Rolling`.
+
+-> **NOTE:** This can only be configured when `priority` is set to `Spot`.
+
+* `overprovision` - (Optional) Should Azure over-provision Virtual Machines in this Scale Set? This means that multiple Virtual Machines will be provisioned and Azure will keep the instances which become available first - which improves provisioning success rates and improves deployment time. You're not billed for these over-provisioned VM's and they don't count towards the Subscription Quota. Defaults to `true`.
+
+* `plan` - (Optional) A `plan` block as documented below.
+
+-> **NOTE:** When using an image from Azure Marketplace a `plan` must be specified.
+
+* `platform_fault_domain_count` - (Optional) Specifies the number of fault domains that are used by this Linux Virtual Machine Scale Set. Changing this forces a new resource to be created.
+
+-> **NOTE:** When `priority` is set to `Spot` an `eviction_policy` must be specified.
+
+* `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on each Virtual Machine in the Scale Set? Defaults to `true`. Changing this value forces a new resource to be created.
+
+* `scale_in_policy` - (Optional) The scale-in policy rule that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled in. Possible values for the scale-in policy rules are `Default`, `NewestVM` and `OldestVM`, defaults to `Default`. For more information about scale in policy, please [refer to this doc](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-scale-in-policy).
+
+* `secret` - (Optional) One or more `secret` blocks as defined below.
+
+* `single_placement_group` - (Optional) Should this Virtual Machine Scale Set be limited to a Single Placement Group, which means the number of instances will be capped at 100 Virtual Machines. Defaults to `true`.
+
+* `source_image_id` - (Optional) The ID of an Image which each Virtual Machine in this Scale Set should be based on.
+
+-> **NOTE:** One of either `source_image_id` or `source_image_reference` must be set.
+
+* `source_image_reference` - (Optional) A `source_image_reference` block as defined below.
+
+-> **NOTE:** One of either `source_image_id` or `source_image_reference` must be set.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to this Virtual Machine Scale Set.
+
+* `terminate_notification` - (Optional) A `terminate_notification` block as defined below.
+
+* `upgrade_mode` - (Optional) Specifies how Upgrades (e.g. changing the Image/SKU) should be performed to Virtual Machine Instances. Possible values are `Automatic`, `Manual` and `Rolling`. Defaults to `Manual`.
+
+---
+
+A `additional_capabilities` block supports the following:
+
+* `ultra_ssd_enabled` - (Optional) Should the capacity to enable Data Disks of the `UltraSSD_LRS` storage account type be supported on this Virtual Machine Scale Set? Defaults to `false`. Changing this forces a new resource to be created.
+
+---
+
+A `admin_ssh_key` block supports the following:
+
+* `public_key` - (Required) The Public Key which should be used for authentication, which needs to be at least 2048-bit and in `ssh-rsa` format.
+
+* `username` - (Required) The Username for which this Public SSH Key should be configured.
+
+-> **NOTE:** The Azure VM Agent only allows creating SSH Keys at the path `/home/{username}/.ssh/authorized_keys` - as such this public key will be added/appended to the authorized keys file.
+
+---
+
+A `automatic_os_upgrade_policy` block supports the following:
+
+* `disable_automatic_rollback` - (Required) Should automatic rollbacks be disabled?
+
+* `enable_automatic_os_upgrade` - (Required) Should OS Upgrades automatically be applied to Scale Set instances in a rolling fashion when a newer version of the OS Image becomes available?
+
+---
+
+A `automatic_instance_repair` block supports the following:
+
+* `enabled` - (Required) Should the automatic instance repair be enabled on this Virtual Machine Scale Set?
+
+* `grace_period` - (Optional) Amount of time (in minutes, between 30 and 90, defaults to 30 minutes) for which automatic repairs will be delayed. The grace period starts right after the VM is found unhealthy. The time duration should be specified in ISO 8601 format.
+
+---
+
+A `boot_diagnostics` block supports the following:
+
+* `storage_account_uri` - (Optional) The Primary/Secondary Endpoint for the Azure Storage Account which should be used to store Boot Diagnostics, including Console Output and Screenshots from the Hypervisor.
+
+-> **NOTE:** Passing a null value will utilize a Managed Storage Account to store Boot Diagnostics.
+
+---
+
+A `certificate` block supports the following:
+
+* `url` - (Required) The Secret URL of a Key Vault Certificate.
+
+-> **NOTE:** This can be sourced from the `secret_id` field within the `azurestack_key_vault_certificate` Resource.
+
+~> **NOTE:** The certificate must have been uploaded/created in PFX format, PEM certificates are not currently supported by Azure.
+
+---
+
+A `data_disk` block supports the following:
+
+* `caching` - (Required) The type of Caching which should be used for this Data Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+
+* `create_option` - (Optional) The create option which should be used for this Data Disk. Possible values are `Empty` and `FromImage`. Defaults to `Empty`. (`FromImage` should only be used if the source image includes data disks).
+
+* `disk_size_gb` - (Required) The size of the Data Disk which should be created.
+
+* `lun` - (Required) The Logical Unit Number of the Data Disk, which must be unique within the Virtual Machine.
+
+* `storage_account_type` - (Required) The Type of Storage Account which should back this Data Disk. Possible values include `Standard_LRS` and `Premium_LRS`.
+
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk.
+
+-> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
+
+~> **NOTE:** Disk Encryption Sets are in Public Preview in a limited set of regions
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be enabled for this Data Disk? Defaults to `false`.
+
+-> **NOTE:** This requires that the `storage_account_type` is set to `Premium_LRS` and that `caching` is set to `None`.
+
+---
+
+A `diff_disk_settings` block supports the following:
+
+`option` - (Required) Specifies the Ephemeral Disk Settings for the OS Disk. At this time the only possible value is `Local`. Changing this forces a new resource to be created.
+
+---
+
+An `extension` block supports the following:
+
+* `name` - (Required) The name for the Virtual Machine Scale Set Extension.
+
+* `publisher` - (Required) Specifies the Publisher of the Extension.
+
+* `type` - (Required) Specifies the Type of the Extension.
+
+* `type_handler_version` - (Required) Specifies the version of the extension to use, available versions can be found using the Azure CLI.
+
+* `auto_upgrade_minor_version` - (Optional) Should the latest version of the Extension be used at Deployment Time, if one is available? This won't auto-update the extension on existing installation. Defaults to `true`.
+
+* `automatic_upgrade_enabled` - (Optional) Should the Extension be automatically updated whenever the Publisher releases a new version of this VM Extension? Defaults to `false`.
+
+* `force_update_tag` - (Optional) A value which, when different to the previous value can be used to force-run the Extension even if the Extension Configuration hasn't changed.
+
+* `protected_settings` - (Optional) A JSON String which specifies Sensitive Settings (such as Passwords) for the Extension.
+
+~> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
+
+-> **NOTE:** Rather than defining JSON inline [you can use the `jsonencode` interpolation function](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to define this in a cleaner way.
+
+* `provision_after_extensions` - (Optional) An ordered list of Extension names which this should be provisioned after.
+
+* `settings` - (Optional) A JSON String which specifies Settings for the Extension.
+
+~> **NOTE:** Keys within the `settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
+
+-> **NOTE:** Rather than defining JSON inline [you can use the `jsonencode` interpolation function](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to define this in a cleaner way.
+
+A `ip_configuration` block supports the following:
+
+* `name` - (Required) The Name which should be used for this IP Configuration.
+
+-> **NOTE:**  When the Virtual Machine Scale Set is configured to have public IPs per instance are created with a load balancer, the SKU of the Virtual Machine instance IPs is determined by the SKU of the Virtual Machine Scale Sets Load Balancer (e.g. `Basic` or `Standard`). Alternatively, you may use the `public_ip_prefix_id` field to generate instance-level IPs in a virtual machine scale set as well. The zonal properties of the prefix will be passed to the Virtual Machine instance IPs, though they will not be shown in the output. To view the public IP addresses assigned to the Virtual Machine Scale Sets Virtual Machine instances use the **az vmss list-instance-public-ips --resource-group `ResourceGroupName` --name `VirtualMachineScaleSetName`** CLI command.
+
+-> **NOTE:** When using this field you'll also need to configure a Rule for the Load Balancer, and use a `depends_on` between this resource and the Load Balancer Rule.
+
+* `load_balancer_inbound_nat_rules_ids` - (Optional) A list of NAT Rule ID's from a Load Balancer which this Virtual Machine Scale Set should be connected to.
+
+-> **NOTE:** When using this field you'll also need to configure a Rule for the Load Balancer, and use a `depends_on` between this resource and the Load Balancer Rule.
+
+* `primary` - (Optional) Is this the Primary IP Configuration for this Network Interface? Defaults to `false`.
+
+-> **NOTE:** One `ip_configuration` block must be marked as Primary for each Network Interface.
+
+* `subnet_id` - (Optional) The ID of the Subnet which this IP Configuration should be connected to.
+
+~> `subnet_id` is required if `version` is set to `IPv4`.
+
+* `version` - (Optional) The Internet Protocol Version which should be used for this IP Configuration. Possible values are `IPv4` and `IPv6`. Defaults to `IPv4`.
+
+A `network_interface` block supports the following:
+
+* `name` - (Required) The Name which should be used for this Network Interface. Changing this forces a new resource to be created.
+
+* `ip_configuration` - (Required) One or more `ip_configuration` blocks as defined above.
+
+* `dns_servers` - (Optional) A list of IP Addresses of DNS Servers which should be assigned to the Network Interface.
+
+* `enable_ip_forwarding` - (Optional) Does this Network Interface support IP Forwarding? Defaults to `false`.
+
+* `network_security_group_id` - (Optional) The ID of a Network Security Group which should be assigned to this Network Interface.
+
+* `primary` - (Optional) Is this the Primary IP Configuration?
+
+-> **NOTE:** If multiple `network_interface` blocks are specified, one must be set to `primary`.
+
+---
+
+A `os_disk` block supports the following:
+
+* `caching` - (Required) The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+
+* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS` and `Premium_LRS`.
+
+* `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
+
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this OS Disk.
+
+-> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
+
+~> **NOTE:** Disk Encryption Sets are in Public Preview in a limited set of regions
+
+* `disk_size_gb` - (Optional) The Size of the Internal OS Disk in GB, if you wish to vary from the size used in the image this Virtual Machine Scale Set is sourced from.
+
+-> **NOTE:** If specified this must be equal to or larger than the size of the Image the VM Scale Set is based on. When creating a larger disk than exists in the image you'll need to repartition the disk to use the remaining space.
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be Enabled for this OS Disk? Defaults to `false`.
+
+-> **NOTE:** This requires that the `storage_account_type` is set to `Premium_LRS` and that `caching` is set to `None`.
+
+---
+
+A `plan` block supports the following:
+
+* `name` - (Required) Specifies the name of the image from the marketplace. Changing this forces a new resource to be created.
+
+* `publisher` - (Required) Specifies the publisher of the image. Changing this forces a new resource to be created.
+
+* `product` - (Required) Specifies the product of the image from the marketplace. Changing this forces a new resource to be created.
+
+---
+
+A `rolling_upgrade_policy` block supports the following:
+
+* `max_batch_instance_percent` - (Required) The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability.
+
+* `max_unhealthy_instance_percent` - (Required) The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch.
+
+* `max_unhealthy_upgraded_instance_percent` - (Required) The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts.
+
+* `pause_time_between_batches` - (Required) The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format.
+
+---
+
+A `secret` block supports the following:
+
+* `certificate` - (Required) One or more `certificate` blocks as defined above.
+
+* `key_vault_id` - (Required) The ID of the Key Vault from which all Secrets should be sourced.
+
+---
+
+A `terminate_notification` block supports the following:
+
+* `enabled` - (Required) Should the terminate notification be enabled on this Virtual Machine Scale Set? Defaults to `false`.
+
+* `timeout` - (Optional) Length of time (in minutes, between 5 and 15) a notification to be sent to the VM on the instance metadata server till the VM gets deleted. The time duration should be specified in ISO 8601 format.
+
+~> **NOTE:** For more information about the terminate notification, please [refer to this doc](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-terminate-notification).
+
+---
+
+`source_image_reference` supports the following:
+
+* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines.
+
+* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines.
+
+* `sku` - (Optional) Specifies the SKU of the image used to create the virtual machines.
+
+* `version` - (Optional) Specifies the version of the image used to create the virtual machines.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Linux Virtual Machine Scale Set.
+
+* `unique_id` - The Unique ID for this Windows Virtual Machine Scale Set.
+
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 60 minutes) Used when creating the Linux Virtual Machine Scale Set.
+* `read` - (Defaults to 5 minutes) Used when reading the Linux Virtual Machine Scale Set.
+* `update` - (Defaults to 60 minutes) Used when updating (and rolling the instances of) the Linux Virtual Machine Scale Set (e.g. when changing SKU).
+* `delete` - (Defaults to 60 minutes) Used when deleting the Linux Virtual Machine Scale Set.
+
+## Import
+
+Linux Virtual Machine Scale Sets can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurestack_linux_virtual_machine_scale_set.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleset1
+```

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -1,14 +1,14 @@
 ---
 subcategory: "Compute"
 layout: "azurestack"
-page_title: "Azure Resource Manager: azurestack_linux_virtual_machine_scale_set"
+page_title: "Azure Resource Manager: azurestack_windows_virtual_machine_scale_set"
 description: |-
-  Manages a Linux Virtual Machine Scale Set.
+  Manages a Windows Virtual Machine Scale Set.
 ---
 
-# azurestack_linux_virtual_machine_scale_set
+# azurestack_windows_virtual_machine_scale_set
 
-Manages a Linux Virtual Machine Scale Set.
+Manages a Windows Virtual Machine Scale Set.
 
 ## Disclaimers
 
@@ -18,9 +18,11 @@ Manages a Linux Virtual Machine Scale Set.
 
 -> **NOTE:** Terraform will automatically update & reimage the nodes in the Scale Set (if Required) during an Update - this behaviour can be configured [using the `features` setting within the Provider block](https://registry.terraform.io/providers/hashicorp/azurestack/latest/docs#features).
 
+~> **NOTE:** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurestack_virtual_machine_scale_set` resource](virtual_machine_scale_set.html) instead
+
 ## Example Usage
 
-This example provisions a basic Linux Virtual Machine Scale Set on an internal network. Additional examples of how to use the `azurestack_linux_virtual_machine_scale_set` resource can be found [in the ./examples/vm-scale-set/linux` directory within the Github Repository](https://github.com/hashicorp/terraform-provider-azurestack/tree/main/examples/vm-scale-set/linux).
+This example provisions a basic Windows Virtual Machine Scale Set on an internal network. Additional examples of how to use the `azurestack_windows_virtual_machine_scale_set` resource can be found [in the ./examples/vm-scale-set/windows` directory within the Github Repository](https://github.com/hashicorp/terraform-provider-azurestack/tree/main/examples/vm-scale-set/windows).
 
 ```hcl
 provider "azurestack" {
@@ -46,23 +48,19 @@ resource "azurestack_subnet" "internal" {
   address_prefix       = "10.0.2.0/24"
 }
 
-resource "azurestack_linux_virtual_machine_scale_set" "example" {
+resource "azurestack_windows_virtual_machine_scale_set" "example" {
   name                = "example-vmss"
   resource_group_name = azurestack_resource_group.example.name
   location            = azurestack_resource_group.example.location
   sku                 = "Standard_F2"
   instances           = 1
+  admin_password      = "P@55w0rd1234!"
   admin_username      = "adminuser"
 
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = file("~/.ssh/id_rsa.pub")
-  }
-
   source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter-Server-Core"
     version   = "latest"
   }
 
@@ -88,11 +86,13 @@ resource "azurestack_linux_virtual_machine_scale_set" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Linux Virtual Machine Scale Set. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Windows Virtual Machine Scale Set. Changing this forces a new resource to be created.
 
-* `location` - (Required) The Azure location where the Linux Virtual Machine Scale Set should exist. Changing this forces a new resource to be created.
+* `location` - (Required) The Azure location where the Windows Virtual Machine Scale Set should exist. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Linux Virtual Machine Scale Set should be exist. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the Resource Group in which the Windows Virtual Machine Scale Set should be exist. Changing this forces a new resource to be created.
+
+* `admin_password` - (Required) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
 
 * `admin_username` - (Required) The username of the local administrator on each Virtual Machine Scale Set instance. Changing this forces a new resource to be created.
 
@@ -110,15 +110,7 @@ The following arguments are supported:
 
 * `additional_capabilities` - (Optional) A `additional_capabilities` block as defined below.
 
-* `admin_password` - (Optional) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
-
--> **NOTE:** When an `admin_password` is specified `disable_password_authentication` must be set to `false`.
-
-~> **NOTE:** One of either `admin_password` or `admin_ssh_key` must be specified.
-
-* `admin_ssh_key` - (Optional) One or more `admin_ssh_key` blocks as defined below.
-
-~> **NOTE:** One of either `admin_password` or `admin_ssh_key` must be specified.
+* `additional_unattend_content` - (Optional) One or more `additional_unattend_content` blocks as defined below.
 
 * `automatic_os_upgrade_policy` - (Optional) A `automatic_os_upgrade_policy` block as defined below. This can only be specified when `upgrade_mode` is set to `Automatic`.
 
@@ -136,23 +128,17 @@ The following arguments are supported:
 
 * `data_disk` - (Optional) One or more `data_disk` blocks as defined below.
 
-* `disable_password_authentication` - Should Password Authentication be disabled on this Virtual Machine Scale Set? Defaults to `true`.
-
--> In general we'd recommend using SSH Keys for authentication rather than Passwords - but there's tradeoff's to each - please [see this thread for more information](https://security.stackexchange.com/questions/69407/why-is-using-an-ssh-key-more-secure-than-using-passwords).
-
--> **NOTE:** When an `admin_password` is specified `disable_password_authentication` must be set to `false`.
-
 * `do_not_run_extensions_on_overprovisioned_machines` - (Optional) Should Virtual Machine Extensions be run on Overprovisioned Virtual Machines in the Scale Set? Defaults to `false`.
+
+* `enable_automatic_updates` - (Optional) Are automatic updates enabled for this Virtual Machine? Defaults to `true`.
 
 * `encryption_at_host_enabled` - (Optional) Should all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host?
 
 * `extension` - (Optional) One or more `extension` blocks as defined below
 
--> **NOTE:** This can only be configured when `priority` is set to `Spot`.
-
 * `health_probe_id` - (Optional) The ID of a Load Balancer Probe which should be used to determine the health of an instance. This is Required and can only be specified when `upgrade_mode` is set to `Automatic` or `Rolling`.
 
--> **NOTE:** This can only be configured when `priority` is set to `Spot`.
+* `license_type` - (Optional) Specifies the type of on-premise license (also known as [Azure Hybrid Use Benefit](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing)) which should be used for this Virtual Machine Scale Set. Possible values are `None`, `Windows_Client` and `Windows_Server`.
 
 * `overprovision` - (Optional) Should Azure over-provision Virtual Machines in this Scale Set? This means that multiple Virtual Machines will be provisioned and Azure will keep the instances which become available first - which improves provisioning success rates and improves deployment time. You're not billed for these over-provisioned VM's and they don't count towards the Subscription Quota. Defaults to `true`.
 
@@ -161,8 +147,6 @@ The following arguments are supported:
 -> **NOTE:** When using an image from Azure Marketplace a `plan` must be specified.
 
 * `platform_fault_domain_count` - (Optional) Specifies the number of fault domains that are used by this Linux Virtual Machine Scale Set. Changing this forces a new resource to be created.
-
--> **NOTE:** When `priority` is set to `Spot` an `eviction_policy` must be specified.
 
 * `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on each Virtual Machine in the Scale Set? Defaults to `true`. Changing this value forces a new resource to be created.
 
@@ -184,7 +168,11 @@ The following arguments are supported:
 
 * `terminate_notification` - (Optional) A `terminate_notification` block as defined below.
 
+* `timezone` - (Optional) Specifies the time zone of the virtual machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/).
+
 * `upgrade_mode` - (Optional) Specifies how Upgrades (e.g. changing the Image/SKU) should be performed to Virtual Machine Instances. Possible values are `Automatic`, `Manual` and `Rolling`. Defaults to `Manual`.
+
+* `winrm_listener` - (Optional) One or more `winrm_listener` blocks as defined below.
 
 ---
 
@@ -194,13 +182,11 @@ A `additional_capabilities` block supports the following:
 
 ---
 
-A `admin_ssh_key` block supports the following:
+A `additional_unattend_content` block supports the following:
 
-* `public_key` - (Required) The Public Key which should be used for authentication, which needs to be at least 2048-bit and in `ssh-rsa` format.
+* `content` - (Required) The XML formatted content that is added to the unattend.xml file for the specified path and component. Changing this forces a new resource to be created.
 
-* `username` - (Required) The Username for which this Public SSH Key should be configured.
-
--> **NOTE:** The Azure VM Agent only allows creating SSH Keys at the path `/home/{username}/.ssh/authorized_keys` - as such this public key will be added/appended to the authorized keys file.
+* `setting` - (Required) The name of the setting to which the content applies. Possible values are `AutoLogon` and `FirstLogonCommands`. Changing this forces a new resource to be created.
 
 ---
 
@@ -224,17 +210,17 @@ A `boot_diagnostics` block supports the following:
 
 * `storage_account_uri` - (Optional) The Primary/Secondary Endpoint for the Azure Storage Account which should be used to store Boot Diagnostics, including Console Output and Screenshots from the Hypervisor.
 
--> **NOTE:** Passing a null value will utilize a Managed Storage Account to store Boot Diagnostics.
+-> **NOTE:** Passing a null value will utilize a Managed Storage Account to store Boot Diagnostics
 
 ---
 
 A `certificate` block supports the following:
 
+* `store` - (Required) The certificate store on the Virtual Machine where the certificate should be added.
+
 * `url` - (Required) The Secret URL of a Key Vault Certificate.
 
 -> **NOTE:** This can be sourced from the `secret_id` field within the `azurestack_key_vault_certificate` Resource.
-
-~> **NOTE:** The certificate must have been uploaded/created in PFX format, PEM certificates are not currently supported by Azure.
 
 ---
 
@@ -320,6 +306,7 @@ A `ip_configuration` block supports the following:
 
 * `version` - (Optional) The Internet Protocol Version which should be used for this IP Configuration. Possible values are `IPv4` and `IPv6`. Defaults to `IPv4`.
 
+
 A `network_interface` block supports the following:
 
 * `name` - (Required) The Name which should be used for this Network Interface. Changing this forces a new resource to be created.
@@ -372,18 +359,6 @@ A `plan` block supports the following:
 
 ---
 
-A `rolling_upgrade_policy` block supports the following:
-
-* `max_batch_instance_percent` - (Required) The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability.
-
-* `max_unhealthy_instance_percent` - (Required) The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch.
-
-* `max_unhealthy_upgraded_instance_percent` - (Required) The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts.
-
-* `pause_time_between_batches` - (Required) The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format.
-
----
-
 A `secret` block supports the following:
 
 * `certificate` - (Required) One or more `certificate` blocks as defined above.
@@ -398,7 +373,17 @@ A `terminate_notification` block supports the following:
 
 * `timeout` - (Optional) Length of time (in minutes, between 5 and 15) a notification to be sent to the VM on the instance metadata server till the VM gets deleted. The time duration should be specified in ISO 8601 format.
 
-~> **NOTE:** For more information about the terminate notification, please [refer to this doc](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-terminate-notification).
+~> For more information about the terminate notification, please [refer to this doc](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-terminate-notification).
+
+---
+
+A `winrm_listener` block supports the following:
+
+* `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when `protocol` is set to `Https`.
+
+-> **NOTE:** This can be sourced from the `secret_id` field within the `azurestack_key_vault_certificate` Resource.
+
+* `protocol` - (Required) The Protocol of the WinRM Listener. Possible values are `Http` and `Https`.
 
 ---
 
@@ -416,24 +401,23 @@ A `terminate_notification` block supports the following:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the Linux Virtual Machine Scale Set.
+* `id` - The ID of the Windows Virtual Machine Scale Set.
 
 * `unique_id` - The Unique ID for this Windows Virtual Machine Scale Set.
-
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 60 minutes) Used when creating the Linux Virtual Machine Scale Set.
-* `read` - (Defaults to 5 minutes) Used when reading the Linux Virtual Machine Scale Set.
-* `update` - (Defaults to 60 minutes) Used when updating (and rolling the instances of) the Linux Virtual Machine Scale Set (e.g. when changing SKU).
-* `delete` - (Defaults to 60 minutes) Used when deleting the Linux Virtual Machine Scale Set.
+* `create` - (Defaults to 60 minutes) Used when creating the Windows Virtual Machine Scale Set.
+* `read` - (Defaults to 5 minutes) Used when reading the Windows Virtual Machine Scale Set.
+* `update` - (Defaults to 60 minutes) Used when updating (and rolling the instances of) the Windows Virtual Machine Scale Set (e.g. when changing SKU).
+* `delete` - (Defaults to 60 minutes) Used when deleting the Windows Virtual Machine Scale Set.
 
 ## Import
 
-Linux Virtual Machine Scale Sets can be imported using the `resource id`, e.g.
+Windows Virtual Machine Scale Sets can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurestack_linux_virtual_machine_scale_set.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleset1
+terraform import azurestack_windows_virtual_machine_scale_set.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleset1
 ```


### PR DESCRIPTION
- Added a resource for Linux virtual machine scale set, and its tests called `azurestack_linux_virtual_machine_scale_set`
- Added a resource for Windows virtual machine scale set, and its tests called `azurestack_windows_virtual_machine_scale_set`
- Removed one test from Unmanaged disk because it is not supported the way it mirrors the same VHD for multiple VMs