### PR TITLE
failed to retrive storage token

### DIFF
--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -66,7 +66,8 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 	}
 
 	// Storage Endpoints
-	storageAuth, err := builder.AuthConfig.GetADALToken(ctx, sender, oauthConfig, endpoint)
+	// storageAuth, err := builder.AuthConfig.GetADALToken(ctx, sender, oauthConfig, endpoint)
+	storageAuth, err := builder.AuthConfig.GetADALToken(ctx, sender, oauthConfig, env.TokenAudience)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get authorization token for storage endpoints: %+v", err)
 	}


### PR DESCRIPTION
unable to get authorization token for storage endpoints when authenticating using a Service Principal using a Client Certificate in ASDK 1.2206

The error is like the following:
│ Error: unable to get authorization token for storage endpoints: adal: Refresh request failed. Status Code = '400'. Response body: {"error":"invalid_resource","error_description":"MSIS9602: The received \u0027resource\u0027 parameter is invalid. The authorization server can not find a registered resource with the specified identifier."} Endpoint https://adfs.local.azurestack.external/adfs/oauth2/token?api-version=1.0

I reckon because the endpoint is ResourceManagerEndpoint which is not a valid resource.  BTW StorageAuthorizer seems  not to be used

