### PR TITLE
Update virtual_network_gateway_resource with new fast path SKus

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -717,5 +717,8 @@ func validateVirtualNetworkGatewayPolicyBasedVpnSku() pluginsdk.SchemaValidateFu
 		string(network.VirtualNetworkGatewaySkuTierBasic),
 		string(network.VirtualNetworkGatewaySkuTierStandard),
 		string(network.VirtualNetworkGatewaySkuTierHighPerformance),
+		string(network.VirtualNetworkGatewaySkuTierVpnGw1),
+		string(network.VirtualNetworkGatewaySkuTierVpnGw2),
+		string(network.VirtualNetworkGatewaySkuTierVpnGw3),
 	}, true)
 }


### PR DESCRIPTION
This PR addresses my Issue here: #276 

Made the change myself to support new Fast Path SKUs. It is very straightforward. It has been tested and it's working.

However - this one has a strong dependency on this PR, adding the missing network association resources mostly:
https://github.com/hashicorp/terraform-provider-azurestack/pull/206

Release **v1.0.0** is simply not usable and completely broken without those essentials network resources.